### PR TITLE
Fix: Claims page points calculations

### DIFF
--- a/hooks/use-tap-processing.ts
+++ b/hooks/use-tap-processing.ts
@@ -156,13 +156,12 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(idempotencyKey && { 'Idempotency-Key': idempotencyKey }),
+          'Accept': 'application/json',
           ...authHeaders,
         },
         body: JSON.stringify(tapInPayload),
         signal: controller.signal,
       });
-      clearTimeout(timeoutId);
 
       if (!response.ok) {
         let errorMessage = 'Failed to process tap-in';
@@ -232,6 +231,7 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         variant: "destructive",
       });
     } finally {
+      clearTimeout(timeoutId);
       setIsProcessing(false);
       processingStarted.current = false;
     }

--- a/hooks/use-tap-processing.ts
+++ b/hooks/use-tap-processing.ts
@@ -96,6 +96,10 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
     setIsProcessing(true);
     setError(null);
 
+    // Declare timeout and controller outside try block for proper cleanup
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     try {
       // Decode additional data if present
       let additionalData: AdditionalData = {};
@@ -150,8 +154,7 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
       // Get authentication headers
       const authHeaders = await getAuthHeaders();
       
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 30000);
+      timeoutId = setTimeout(() => controller.abort(), 30000);
       const response = await fetch('/api/tap-in', {
         method: 'POST',
         headers: {
@@ -231,7 +234,7 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         variant: "destructive",
       });
     } finally {
-      clearTimeout(timeoutId);
+      if (timeoutId) clearTimeout(timeoutId);
       setIsProcessing(false);
       processingStarted.current = false;
     }

--- a/hooks/use-tap-processing.ts
+++ b/hooks/use-tap-processing.ts
@@ -143,11 +143,9 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         }
       };
 
-      // Generate idempotency key for double-submit protection
-      // Use stable key when qrId is present to ensure proper duplicate prevention
-      const idempotencyKey = qrId
-        ? `tap-in:${clubId}:${source}:${qrId}`
-        : `tap-in:${clubId}:${source}:${Date.now()}:${Math.random().toString(36).slice(2, 11)}`;
+      // Let the backend generate user-specific idempotency key to avoid conflicts
+      // Frontend-generated keys were causing multiple users to share the same ref
+      const idempotencyKey = `tap-in:${Date.now()}:${Math.random().toString(36).slice(2, 11)}`;
 
       // Get authentication headers
       const authHeaders = await getAuthHeaders();

--- a/hooks/use-tap-processing.ts
+++ b/hooks/use-tap-processing.ts
@@ -143,9 +143,9 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         }
       };
 
-      // Let the backend generate user-specific idempotency key to avoid conflicts
-      // Frontend-generated keys were causing multiple users to share the same ref
-      const idempotencyKey = `tap-in:${Date.now()}:${Math.random().toString(36).slice(2, 11)}`;
+      // Let backend generate user-specific idempotency key based on user context
+      // This prevents multiple users from sharing the same ref while maintaining retry safety
+      const idempotencyKey = undefined; // Backend will generate user-specific key
 
       // Get authentication headers
       const authHeaders = await getAuthHeaders();
@@ -156,7 +156,7 @@ export function useTapProcessing(): TapProcessingState & TapProcessingActions {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Idempotency-Key': idempotencyKey,
+          ...(idempotencyKey && { 'Idempotency-Key': idempotencyKey }),
           ...authHeaders,
         },
         body: JSON.stringify(tapInPayload),

--- a/migrations/018_tap_in_unified_function.sql
+++ b/migrations/018_tap_in_unified_function.sql
@@ -180,7 +180,8 @@ BEGIN
   UPDATE tap_ins SET
     current_status = new_status,
     total_points_after = final_total_points
-  WHERE id = tap_in_record.id;
+  WHERE id = tap_in_record.id
+  RETURNING * INTO tap_in_record;
 
   -- Log transaction
   INSERT INTO point_transactions (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Tap-in points now reflect the finalized post-update balance, preventing mismatched totals and statuses.

- Refactor
  - Duplicate tap-in handling fully moved to the server; client no longer sends idempotency keys and relies on backend idempotency.
  - Client request headers/timing updated: Accept header added, idempotency header removed, and timeout cleanup guaranteed.

- Chores
  - Transaction source standardized to "earned".
  - Server now defers final total-point calculation, uses a race-safe upsert, and returns an idempotent=true payload for duplicate tap-ins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->