### PR TITLE
fix: final UI updates for the initial campaign launch

### DIFF
--- a/app/api/campaigns/credit-purchase/route.ts
+++ b/app/api/campaigns/credit-purchase/route.ts
@@ -166,7 +166,7 @@ export async function POST(request: NextRequest) {
         },
         quantity: 1
       }],
-      success_url: success_url || `${baseUrl.replace(/\/$/, '')}/dashboard?credit_purchase_success=true&club_id=${club_id}`,
+      success_url: success_url || `${baseUrl.replace(/\/$/, '')}/dashboard?purchase_success=true&club_id=${club_id}&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: cancel_url || `${baseUrl.replace(/\/$/, '')}/dashboard?club_id=${club_id}`,
       metadata: {
         type: 'direct_credit_purchase',

--- a/components/campaign-progress-card.tsx
+++ b/components/campaign-progress-card.tsx
@@ -61,7 +61,7 @@ export function CampaignProgressCard({ campaignData, clubId }: CampaignProgressC
         body: JSON.stringify({
           club_id: clubId,
           credit_amount: creditAmount,
-          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_success=true`,
+          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true`,
           cancel_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_cancelled=true`
         })
       });

--- a/components/campaign-progress-card.tsx
+++ b/components/campaign-progress-card.tsx
@@ -61,7 +61,7 @@ export function CampaignProgressCard({ campaignData, clubId }: CampaignProgressC
         body: JSON.stringify({
           club_id: clubId,
           credit_amount: creditAmount,
-          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true`,
+          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true&session_id={CHECKOUT_SESSION_ID}`,
           cancel_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_cancelled=true`
         })
       });

--- a/components/club-details-modal.tsx
+++ b/components/club-details-modal.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useUnifiedAuth } from "@/lib/unified-auth-context";
+import { usePrivy } from "@privy-io/react-auth";
 import type { Club, ClubMembership, ClubStatus } from "@/types/club.types";
 import type { CampaignData } from "@/types/campaign.types";
 import { getNextStatus, getPointsToNext, STATUS_COLORS } from "@/types/club.types";
@@ -80,6 +81,7 @@ export default function ClubDetailsModal({
   autoOpenWallet = false,
 }: ClubDetailsModalProps) {
   const { user, isAuthenticated } = useUnifiedAuth();
+  const { login } = usePrivy();
   const { toast } = useToast();
   
   // Clear campaign data on club change to avoid stale UI
@@ -145,11 +147,8 @@ export default function ClubDetailsModal({
 
   const handleJoinClub = async () => {
     if (!isAuthenticated || !user?.id) {
-      toast({
-        title: "Sign in required",
-        description: "Please sign in to add memberships",
-        variant: "destructive",
-      });
+      // Open Privy login modal instead of showing error toast
+      login();
       return;
     }
 
@@ -585,15 +584,10 @@ export default function ClubDetailsModal({
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      handleJoinClub();
+                      handleJoinClub(); // Opens login modal if not authenticated
                     }}
-                    disabled={joinClubMutation.isPending || !isAuthenticated}
+                    disabled={joinClubMutation.isPending}
                     className="w-full rounded-xl bg-primary py-4 text-center font-semibold text-white shadow-lg shadow-primary/20 transition-all hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                    aria-label={
-                      !isAuthenticated
-                        ? "Sign in required to add memberships"
-                        : undefined
-                    }
                   >
                     {joinClubMutation.isPending ? (
                       <Spinner size="sm" />

--- a/components/club-details-modal.tsx
+++ b/components/club-details-modal.tsx
@@ -400,42 +400,8 @@ export default function ClubDetailsModal({
               </p>
             </div>
 
-            {/* Latest Section - Club Media */}
-            <div className="mb-8">
-              <h3 className="mb-4 text-xl font-semibold">Latest</h3>
-              {/* Container with responsive sizing - Desktop: video left, Mobile: centered */}
-              <div className="flex justify-center md:justify-start">
-                <div className="relative rounded-3xl overflow-hidden bg-gradient-to-br from-gray-900/80 to-gray-900/40 border border-gray-700/50 shadow-2xl backdrop-blur-sm w-full max-w-2xl md:max-w-lg">
-                  <div className="relative aspect-video md:aspect-[4/3]">
-                    <ClubMediaDisplay
-                      clubId={club.id}
-                      className="w-full h-full"
-                      showControls={true}
-                      autoPlay={false}
-                      fallbackImage="/placeholder.svg?height=400&width=600&query=music club"
-                    />
-                  {/* Subtle overlay for better text contrast */}
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
-                </div>
-                
-                {/* Enhanced content section */}
-                <div className="p-5 bg-gradient-to-r from-gray-900/90 to-gray-800/90 backdrop-blur-sm">
-                  <h4 className="font-bold text-white text-lg mb-3">Recent Updates from {club.name}</h4>
-                  
-                  {/* Cool accent line */}
-                  <div className="w-12 h-0.5 bg-gradient-to-r from-primary to-purple-400 rounded-full"></div>
-                </div>
-                
-                {/* Subtle glow effect */}
-                <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-primary/10 via-transparent to-purple-500/10 pointer-events-none"></div>
-                </div>
-              </div>
-            </div>
-
-
-            {/* Store Section */}
-            {membership && (
-              <div className="mb-8" ref={rewardsRef}>
+            {/* Store Section - Always visible even for non-members */}
+            <div className="mb-8" ref={rewardsRef}>
                 {/* Main Section Header */}
                 <h3 className="mb-4 text-xl font-semibold">Store</h3>
                 
@@ -476,7 +442,6 @@ export default function ClubDetailsModal({
                   }}
                 />
               </div>
-            )}
 
             {/* Your Status Section - Moved Below Campaign Rewards */}
             {membership != null ? (
@@ -506,7 +471,37 @@ export default function ClubDetailsModal({
               </div>
             )}
 
-
+            {/* Latest Section - Club Media */}
+            <div className="mb-8">
+              <h3 className="mb-4 text-xl font-semibold">Latest</h3>
+              {/* Container with responsive sizing - Desktop: video left, Mobile: centered */}
+              <div className="flex justify-center md:justify-start">
+                <div className="relative rounded-3xl overflow-hidden bg-gradient-to-br from-gray-900/80 to-gray-900/40 border border-gray-700/50 shadow-2xl backdrop-blur-sm w-full max-w-2xl md:max-w-lg">
+                  <div className="relative aspect-video md:aspect-[4/3]">
+                    <ClubMediaDisplay
+                      clubId={club.id}
+                      className="w-full h-full"
+                      showControls={true}
+                      autoPlay={false}
+                      fallbackImage="/placeholder.svg?height=400&width=600&query=music club"
+                    />
+                  {/* Subtle overlay for better text contrast */}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
+                </div>
+                
+                {/* Enhanced content section */}
+                <div className="p-5 bg-gradient-to-r from-gray-900/90 to-gray-800/90 backdrop-blur-sm">
+                  <h4 className="font-bold text-white text-lg mb-3">Recent Updates from {club.name}</h4>
+                  
+                  {/* Cool accent line */}
+                  <div className="w-12 h-0.5 bg-gradient-to-r from-primary to-purple-400 rounded-full"></div>
+                </div>
+                
+                {/* Subtle glow effect */}
+                <div className="absolute inset-0 rounded-3xl bg-gradient-to-br from-primary/10 via-transparent to-purple-500/10 pointer-events-none"></div>
+                </div>
+              </div>
+            </div>
 
             {/* Club Details Grid - Moved to Bottom */}
             <div className="mb-8">

--- a/components/unified-economy/unified-points-wallet.tsx
+++ b/components/unified-economy/unified-points-wallet.tsx
@@ -312,7 +312,7 @@ export default function UnifiedPointsWallet({
         body: JSON.stringify({
           club_id: clubId,
           credit_amount: creditAmount, // Number of credits to purchase
-          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true`,
+          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true&session_id={CHECKOUT_SESSION_ID}`,
           cancel_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_cancelled=true`
         })
       });

--- a/components/unified-economy/unified-points-wallet.tsx
+++ b/components/unified-economy/unified-points-wallet.tsx
@@ -312,7 +312,7 @@ export default function UnifiedPointsWallet({
         body: JSON.stringify({
           club_id: clubId,
           credit_amount: creditAmount, // Number of credits to purchase
-          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_success=true`,
+          success_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&purchase_success=true`,
           cancel_url: `${window.location.origin}${window.location.pathname}?club_id=${clubId}&credit_purchase_cancelled=true`
         })
       });


### PR DESCRIPTION
Direct credit purchases now use same success URL as item purchases:
- Both use: purchase_success=true&club_id=X&session_id=Y
- Both open club modal automatically
- Both auto-open wallet with confetti
- Both show success toast
- Consistent UX for all purchase types

Auth Flow:
- Unauthenticated users get Privy login modal (not disabled buttons)
- Share links work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes checkout success URLs (with session_id) and enhances unauthenticated login UX in the club modal while exposing Store to non-members and reorganizing sections.
> 
> - **Checkout/Payments**:
>   - Standardize success URL to `purchase_success=true&club_id=...&session_id={CHECKOUT_SESSION_ID}` in `app/api/campaigns/credit-purchase/route.ts`, `components/campaign-progress-card.tsx`, and `components/unified-economy/unified-points-wallet.tsx`.
> - **Auth & Club Modal UX** (`components/club-details-modal.tsx`):
>   - Integrate Privy: auto-trigger login on open for unauthenticated users; `handleJoinClub` invokes `login()` instead of showing an error.
>   - Make **Store** visible to unauthenticated users with a login prompt; remove membership gating around the section.
>   - Join button remains enabled (only shows pending state) and triggers login when needed.
>   - Reorder content: move "Latest" media section below Store/details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5657fb940529e28dd9c61830a4eafb451df9f33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Club join now opens an in-context Privy login modal for unauthenticated users (auto-triggers when the club modal is opened).
  - Join button only reflects pending state; clicking will prompt login if needed.

- UI Changes
  - Club modal: Latest media repositioned and Store section visible to non-members with a login prompt.

- Bug Fixes
  - Checkout redirect updated to include session_id and use a standardized purchase_success flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->