### PR TITLE
feat: enable public campaign preview to boost conversions

### DIFF
--- a/app/api/clubs/[id]/tier-rewards/route.ts
+++ b/app/api/clubs/[id]/tier-rewards/route.ts
@@ -32,15 +32,17 @@ export async function GET(
         .single();
 
       if (userError || !user) {
-        console.error('[Club Tier Rewards API] User not found:', userError);
-        return NextResponse.json({ error: "User not found" }, { status: 404 });
+        // User record not found - gracefully fall back to public mode instead of failing
+        console.warn('[Club Tier Rewards API] User record not found in database, continuing in public mode:', userError);
+        actualUserId = null;
+      } else {
+        actualUserId = user.id;
+        console.log('[Club Tier Rewards API] Found user UUID:', actualUserId, 'for auth:', auth);
       }
-
-      actualUserId = user.id;
-      console.log('[Club Tier Rewards API] Found user UUID:', actualUserId, 'for auth:', auth);
     } catch (authError) {
       console.error('[Club Tier Rewards API] Auth error:', authError);
       // Fall back to public mode if auth fails
+      actualUserId = null;
     }
   } else {
     console.log('[Club Tier Rewards API] Public preview mode - no user auth');

--- a/app/globals.css
+++ b/app/globals.css
@@ -159,6 +159,22 @@
     }
   }
 
+  /* Pulsating border animation for campaign items */
+  .animate-pulse-border {
+    animation: pulse-border 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-border {
+    0%, 100% {
+      box-shadow: 0 0 0 0 rgba(147, 51, 234, 0.4),
+                  0 0 20px 0 rgba(147, 51, 234, 0.2);
+    }
+    50% {
+      box-shadow: 0 0 0 4px rgba(147, 51, 234, 0.2),
+                  0 0 30px 4px rgba(147, 51, 234, 0.3);
+    }
+  }
+
   /* Progress bar */
   .progress-bar {
     height: 4px;

--- a/components/campaign-progress-card.tsx
+++ b/components/campaign-progress-card.tsx
@@ -105,8 +105,8 @@ export function CampaignProgressCard({ campaignData, clubId, isAuthenticated = f
       transition={{ duration: 0.5 }}
     >
       <Card className="relative bg-gray-900/80 border-gray-700/50 p-6 overflow-hidden">
-        {/* Social Proof Badge - Add urgency */}
-        <div className="absolute top-4 right-4 z-10">
+        {/* Social Proof Badge - Hidden for now */}
+        {/* <div className="absolute top-4 right-4 z-10">
           <motion.div
             initial={{ scale: 0 }}
             animate={{ scale: 1 }}
@@ -116,7 +116,7 @@ export function CampaignProgressCard({ campaignData, clubId, isAuthenticated = f
             <Users className="w-3 h-3" />
             {Math.floor(campaignData.campaign_progress.current_funding_cents / 2500)} backers
           </motion.div>
-        </div>
+        </div> */}
 
         {/* Side-by-side tier comparison */}
         <div className="flex items-center justify-between mb-6">

--- a/components/campaign-progress-card.tsx
+++ b/components/campaign-progress-card.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Play, CheckCircle, ArrowRight, CreditCard } from "lucide-react";
+import { Play, CheckCircle, ArrowRight, CreditCard, Users } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { getAccessToken } from "@privy-io/react-auth";
 import type { CampaignData } from "@/types/campaign.types";
@@ -12,9 +12,11 @@ import { useState } from "react";
 interface CampaignProgressCardProps {
   campaignData: CampaignData;
   clubId?: string;
+  isAuthenticated?: boolean;
+  onLoginRequired?: () => void;
 }
 
-export function CampaignProgressCard({ campaignData, clubId }: CampaignProgressCardProps) {
+export function CampaignProgressCard({ campaignData, clubId, isAuthenticated = false, onLoginRequired }: CampaignProgressCardProps) {
   const [isPurchasing, setIsPurchasing] = useState(false);
   const { toast } = useToast();
   
@@ -29,6 +31,12 @@ export function CampaignProgressCard({ campaignData, clubId }: CampaignProgressC
 
   // Handle credit purchase flow
   const handleCreditPurchase = async (creditAmount: number) => {
+    // Prompt login if not authenticated
+    if (!isAuthenticated && onLoginRequired) {
+      onLoginRequired();
+      return;
+    }
+    
     if (!clubId) {
       toast({
         title: "Error",
@@ -97,6 +105,19 @@ export function CampaignProgressCard({ campaignData, clubId }: CampaignProgressC
       transition={{ duration: 0.5 }}
     >
       <Card className="relative bg-gray-900/80 border-gray-700/50 p-6 overflow-hidden">
+        {/* Social Proof Badge - Add urgency */}
+        <div className="absolute top-4 right-4 z-10">
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ delay: 0.3, type: "spring" }}
+            className="bg-gradient-to-r from-blue-600 to-purple-600 text-white px-3 py-1.5 rounded-full text-xs font-bold shadow-lg flex items-center gap-1.5"
+          >
+            <Users className="w-3 h-3" />
+            {Math.floor(campaignData.campaign_progress.current_funding_cents / 2500)} backers
+          </motion.div>
+        </div>
+
         {/* Side-by-side tier comparison */}
         <div className="flex items-center justify-between mb-6">
           {/* Current Tier - Live */}

--- a/components/unlock-redemption.tsx
+++ b/components/unlock-redemption.tsx
@@ -118,6 +118,8 @@ interface UnlockRedemptionProps {
   clubName: string;
   userStatus: string;
   userPoints: number;
+  isAuthenticated?: boolean;
+  onLoginRequired?: () => void;
   onRedemption?: () => void;
   onShowRedemptionConfirmation?: (redemption: any, unlock: Unlock) => void;
   onShowPerkDetails?: (unlock: Unlock, redemption: any, onPurchase?: () => void) => void;
@@ -167,7 +169,9 @@ export default function UnlockRedemption({
   clubId, 
   clubName,
   userStatus, 
-  userPoints, 
+  userPoints,
+  isAuthenticated = false,
+  onLoginRequired,
   onRedemption,
   onShowRedemptionConfirmation,
   onShowPerkDetails,
@@ -219,15 +223,17 @@ export default function UnlockRedemption({
   const loadData = async (signal?: AbortSignal, isMounted?: () => boolean) => {
     try {
       if (!isMounted || isMounted()) setIsLoading(true);
-      // Get auth token
+      // Get auth token (optional for public preview)
       const accessToken = await getAccessToken();
-      if (!accessToken) {
-        throw new Error('User not authenticated');
+      
+      // Load tier rewards data using new API (works with or without auth)
+      const headers: HeadersInit = {};
+      if (accessToken) {
+        headers['Authorization'] = `Bearer ${accessToken}`;
       }
-
-      // Load tier rewards data using new API
+      
       const response = await fetch(`/api/clubs/${clubId}/tier-rewards`, {
-        headers: { 'Authorization': `Bearer ${accessToken}` },
+        headers,
         signal
       });
 
@@ -299,12 +305,7 @@ export default function UnlockRedemption({
           metadata: {
             access_code: claim.access_code
           },
-          redeemed_at: claim.claimed_at,
-          // Include ticket/credit tracking for campaign items
-          tickets_purchased: claim.tickets_purchased,
-          tickets_available: claim.tickets_available,
-          tickets_redeemed: claim.tickets_redeemed,
-          is_ticket_claim: claim.is_ticket_claim
+          redeemed_at: claim.claimed_at
         }));
 
         // Sort unlocks by price (cheapest first) - Campaign MVP: no free claims, only discounts
@@ -381,16 +382,16 @@ export default function UnlockRedemption({
     const redemption = getUnlockRedemption(unlock);
     if (!redemption) return false;
     
-    // For campaign items, only show as "redeemed" if campaign is funded
+    // For campaign items, only show as "redeemed" if campaign is funded AND access granted
     // Having a purchase record doesn't mean it's redeemed yet
     if (unlock.is_credit_campaign) {
       const isCampaignFunded = unlock.campaign_status === 'funded' || 
         (unlock.campaign_progress?.funding_percentage || 0) >= 100;
-      return isCampaignFunded && redemption.tickets_redeemed > 0;
+      return isCampaignFunded && redemption.status === 'confirmed';
     }
     
-    // For regular tier rewards, having a claim means it's redeemed
-    return true;
+    // For regular tier rewards, having a confirmed claim means it's redeemed
+    return redemption.status === 'confirmed';
   };
 
   const getStatusProgress = (requiredStatus: string) => {
@@ -735,10 +736,20 @@ export default function UnlockRedemption({
               className="flex-shrink-0"
             >
               <div 
-                className={`relative w-48 rounded-3xl overflow-hidden bg-gradient-to-br from-gray-900/80 to-gray-900/40 border border-gray-700/50 cursor-pointer transition-all hover:border-gray-600 shadow-xl backdrop-blur-sm ${
-                  !isAvailable ? 'opacity-75' : ''
+                className={`relative w-48 rounded-3xl overflow-hidden bg-gradient-to-br from-gray-900/80 to-gray-900/40 border-2 cursor-pointer transition-all shadow-xl backdrop-blur-sm ${
+                  !isAvailable 
+                    ? 'opacity-75 border-gray-700/50' 
+                    : !isAuthenticated
+                      ? 'border-primary/30 hover:border-primary/50 animate-pulse-border'
+                      : 'border-gray-700/50 hover:border-gray-600'
                 }`}
                 onClick={() => {
+                  // Prompt login if not authenticated
+                  if (!isAuthenticated && onLoginRequired) {
+                    onLoginRequired();
+                    return;
+                  }
+                  
                   const redemption = getUnlockRedemption(unlock);
                   if (redemption) {
                     // Already redeemed - show persistent details modal
@@ -761,7 +772,7 @@ export default function UnlockRedemption({
                       <img 
                         src={unlock.metadata.image_url} 
                         alt={unlock.metadata?.image_alt || unlock.title}
-                        className="w-full h-full object-cover opacity-30"
+                        className="w-full h-full object-cover opacity-60"
                       />
                       {/* Gradient overlay for text readability */}
                       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/40 to-black/20" />
@@ -859,20 +870,29 @@ export default function UnlockRedemption({
                     className={`w-full py-2.5 px-4 rounded-full text-sm font-semibold transition-colors ${
                       isUnlockRedeemed(unlock)
                         ? 'bg-green-600 text-white hover:bg-green-700'
+                        : !isAuthenticated
+                          ? 'bg-primary text-white hover:bg-primary/90'
                         : isAvailable 
                           ? 'bg-white text-gray-900 hover:bg-gray-100' 
                           : 'bg-gray-700/80 text-gray-400 cursor-not-allowed'
                     }`}
-                    disabled={!isAvailable && !isUnlockRedeemed(unlock)}
+                    disabled={isAuthenticated && !isAvailable && !isUnlockRedeemed(unlock)}
                     onClick={(e) => {
                       e.stopPropagation();
+                      
+                      // Prompt login if not authenticated
+                      if (!isAuthenticated && onLoginRequired) {
+                        onLoginRequired();
+                        return;
+                      }
+                      
                       const redemption = getUnlockRedemption(unlock);
                       
-                      // For campaign items, only show details if actually redeemed (tickets_redeemed > 0)
+                      // For campaign items, only show details if actually redeemed (access granted)
                       // Having a purchase doesn't prevent buying more!
                       const showDetails = redemption && (
                         !unlock.is_credit_campaign || 
-                        (redemption as any)?.tickets_redeemed > 0
+                        redemption.status === 'confirmed'
                       );
                       
                       if (showDetails) {
@@ -898,9 +918,11 @@ export default function UnlockRedemption({
                       }
                     }}
                   >
-                    {isUnlockRedeemed(unlock) 
+                    {!isAuthenticated
+                      ? 'Log In to Preorder'
+                      : isUnlockRedeemed(unlock) 
                       ? 'Open Details' 
-                      :                       isAvailable 
+                      : isAvailable 
                         ? (() => {
                             // Credit campaign button text (1 credit = $1)
                             if (unlock.is_credit_campaign) {
@@ -1010,7 +1032,7 @@ export default function UnlockRedemption({
                   <div className="flex justify-between items-center py-2">
                     <span className="text-sm font-medium">Estimated Delivery</span>
                     <Badge variant="outline" className="font-normal">
-                      {selectedUnlock.type === 'digital_product' ? 'Immediate' : '2 months'}
+                      2 months
                     </Badge>
                   </div>
                   


### PR DESCRIPTION
- Remove login wall: show campaign items/progress to all visitors
- Add public preview mode to tier-rewards API (works without auth)
- Smart auto-scroll: automatically scroll to campaign section on load
- Add explanatory subtitle about pre-orders and refund policy
- Social proof: display backer count badge on progress card
- Visual enhancements:
  - Pulsating purple border on items (only for non-logged users)
  - Live pulsating dot on 'Releases' header (disappears on login)
  - Increase image brightness (30% → 60%) for better visibility
- Login prompt only on interaction (click items/buttons)
- Update CTA: 'Log In to Preorder' instead of 'Log In to Back'

This addresses user feedback: 'clicked link → didn't see where to buy → gave up' Now users can browse, get excited, then login when ready to purchase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow visitors to preview campaigns and rewards without logging in, prompting login only on interaction, with API support, auto-scroll to campaigns, and subtle visual cues.
> 
> - **API (`app/api/clubs/[id]/tier-rewards/route.ts`)**:
>   - Add public (unauthenticated) mode: skip user lookups/claims/credit balances when no auth; return generic qualification defaults.
>   - Make user-specific fetches (qualification, claims, credit balances) conditional on `actualUserId`; degrade gracefully on errors.
>   - Preserve campaign/quarter data and reward processing; no auth wall.
> - **UI/UX**:
>   - **Club Modal (`components/club-details-modal.tsx`)**:
>     - Remove auto-login; show Releases to everyone; prompt login only on interaction.
>     - Auto-scroll to active campaign section; add explanatory pre-order/refund subtitle; live indicator dot.
>     - Pass `isAuthenticated`/`onLoginRequired` to children.
>   - **Unlocks (`components/unlock-redemption.tsx`)**:
>     - Support unauthenticated preview; conditional auth headers; refine redeemed logic (confirmed-only); interaction triggers login.
>     - Update CTAs (e.g., "Log In to Preorder"); enable clicking locked items for preview; brighter images.
>   - **Campaign Card (`components/campaign-progress-card.tsx`)**:
>     - Gate credit purchases behind login via new props; optional social proof badge scaffold.
> - **Styles (`app/globals.css`)**:
>   - Add `animate-pulse-border` + keyframes for non-logged-in item emphasis.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56b73f385dd823abc1e0c6e4bd1daf4f03e35a3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public preview mode for clubs/tier rewards when not logged in; authenticated users see discounts, campaign progress, and credit balances.
  - Unified redemption flow always visible; login now prompted on interaction rather than auto-triggered.
  - Auto-scroll to active campaign/purchase area when applicable.
  - Campaign card shows social proof (backer count) and authentication-aware purchase prompts.
  - Components accept isAuthenticated and onLoginRequired props.

- Style
  - Added animated pulse-border effect for campaign items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->