### PR TITLE
Extension: Solana Adapter

### DIFF
--- a/solana-adapter/.gitignore
+++ b/solana-adapter/.gitignore
@@ -1,0 +1,21 @@
+# Anchor
+.anchor
+target/
+test-ledger/
+
+# IDL
+*.so
+
+# Node
+node_modules/
+dist/
+*.log
+
+# Solana
+.DS_Store
+deploy/
+
+# Environment
+.env
+.env.local
+

--- a/solana-adapter/ARCHITECTURE.md
+++ b/solana-adapter/ARCHITECTURE.md
@@ -1,0 +1,456 @@
+# Architecture: Superfan Solana Adapter
+
+Deep dive into the technical design and implementation details.
+
+## 🎯 Design Goals
+
+1. **Functional Parity**: Replicate Metal's presale flow with Solana primitives
+2. **Zero-Crypto UX**: Abstract blockchain complexity via Privy
+3. **Security**: Leverage Solana's account model for safe escrow
+4. **Composability**: Design for future DeFi integrations
+5. **Maintainability**: Mirror Base contract patterns where possible
+
+## 🏗️ System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend (Next.js)                    │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────┐│
+│  │  Privy Auth     │  │  React UI       │  │  Presale     ││
+│  │  (Solana)       │  │  Components     │  │  Banner      ││
+│  └────────┬────────┘  └────────┬────────┘  └──────┬───────┘│
+└───────────┼─────────────────────┼───────────────────┼────────┘
+            │                     │                   │
+            └─────────────────────┼───────────────────┘
+                                  │
+                    ┌─────────────▼────────────┐
+                    │   API Routes (Next.js)   │
+                    │  /api/presale/buy        │
+                    │  /api/presale/stats      │
+                    └─────────────┬────────────┘
+                                  │
+                    ┌─────────────▼────────────┐
+                    │  Solana Adapter Client   │
+                    │  (TypeScript SDK)        │
+                    └─────────────┬────────────┘
+                                  │
+                    ┌─────────────▼────────────┐
+                    │   @solana/web3.js        │
+                    │   @coral-xyz/anchor      │
+                    └─────────────┬────────────┘
+                                  │
+                                  │ RPC
+                                  │
+┌─────────────────────────────────▼─────────────────────────────┐
+│                      Solana Runtime                            │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │           Superfan Presale Program (Rust)                │ │
+│  │                                                          │ │
+│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐    │ │
+│  │  │  Campaign   │  │    SPL      │  │   USDC      │    │ │
+│  │  │  State PDA  │  │ Token Mint  │  │  Treasury   │    │ │
+│  │  └─────────────┘  └─────────────┘  └─────────────┘    │ │
+│  └──────────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────┘
+```
+
+## 🔐 On-Chain Architecture
+
+### Account Model
+
+```
+Campaign PDA
+├── Authority: Pubkey        // Campaign creator
+├── Campaign ID: String      // "artist-presale-2024"
+├── Token Mint: Pubkey       // SPL token for campaign
+├── Treasury: Pubkey         // USDC escrow account
+├── Price: u64               // USDC per token (6 decimals)
+├── Total Supply: Option<u64> // Max tokens
+├── Tokens Sold: u64         // Current sold
+├── USDC Raised: u64         // Current funding
+├── Is Active: bool          // Campaign status
+└── Bump: u8                 // PDA bump seed
+
+Campaign Token Mint (SPL Token)
+├── Mint Authority: Campaign PDA
+├── Decimals: 6
+└── Supply: Dynamic
+
+Treasury (Token Account)
+├── Mint: USDC
+├── Owner: Campaign PDA
+└── Balance: USDC raised
+```
+
+### PDA Derivation
+
+```rust
+// Campaign PDA
+seeds = [
+  b"campaign",
+  campaign_id.as_bytes()
+]
+
+// Example:
+// campaign_id = "artist-presale-2024"
+// PDA = findProgramAddress([
+//   "campaign",
+//   "artist-presale-2024"
+// ])
+```
+
+**Benefits:**
+- Deterministic addresses
+- No collisions (unique per campaign_id)
+- Authority derived from program logic
+
+### Token Flow
+
+```
+                    buy_presale(100 USDC)
+                           │
+          ┌────────────────┼────────────────┐
+          │                │                │
+          ▼                ▼                ▼
+    ┌─────────┐      ┌─────────┐     ┌─────────┐
+    │  Buyer  │      │Campaign │     │ Buyer   │
+    │  USDC   │─────▶│Treasury │     │Campaign │
+    │ Account │      │ (PDA)   │     │ Tokens  │
+    └─────────┘      └─────────┘     └─────────┘
+                           │                ▲
+                           │                │
+                           └────────────────┘
+                         mint_to(66.67 tokens)
+                         (100 USDC / 1.5 price)
+```
+
+**Transaction is atomic:**
+- USDC transfer succeeds → token mint succeeds
+- Either fails → entire transaction reverts
+
+## 🔄 Instruction Flow
+
+### 1. `initialize_campaign`
+
+```
+Signer: Artist Wallet
+────────────────────────────────────────────────
+Accounts Created:
+  1. Campaign PDA (new)
+  2. Campaign Token Mint (new)
+  3. Treasury Token Account (new, owned by Campaign PDA)
+
+State Changes:
+  - Campaign initialized with metadata
+  - Token mint created (authority = Campaign PDA)
+  - Treasury ready to receive USDC
+
+Cost: ~0.01 SOL
+```
+
+### 2. `buy_presale`
+
+```
+Signer: Fan Wallet
+────────────────────────────────────────────────
+Pre-flight Checks:
+  ✓ Campaign is active
+  ✓ USDC amount > 0
+  ✓ Supply not exceeded
+  ✓ Buyer has sufficient USDC
+
+Transfers:
+  1. USDC: Buyer → Treasury (token::transfer)
+  2. Tokens: Mint → Buyer (token::mint_to)
+
+State Changes:
+  - campaign.tokens_sold += tokens_minted
+  - campaign.usdc_raised += usdc_spent
+
+Cost: ~0.00002 SOL
+```
+
+### 3. `withdraw_funds`
+
+```
+Signer: Artist Wallet (must be campaign.authority)
+────────────────────────────────────────────────
+Pre-flight Checks:
+  ✓ Caller is campaign authority
+  ✓ Amount ≤ treasury balance
+
+Transfer:
+  USDC: Treasury → Artist (token::transfer)
+  Signed by Campaign PDA (using seeds)
+
+State Changes:
+  - None (treasury balance decreases naturally)
+
+Cost: ~0.00001 SOL
+```
+
+## 🔒 Security Model
+
+### Authority Control
+
+```rust
+// Only campaign creator can withdraw
+#[account(
+  has_one = authority  // Enforces authority == signer
+)]
+pub campaign: Account<'info, Campaign>,
+
+pub authority: Signer<'info>,
+```
+
+### Supply Caps
+
+```rust
+// Prevent over-minting
+if let Some(total_supply) = campaign.total_supply {
+  let new_total = campaign.tokens_sold + tokens_to_mint;
+  require!(new_total <= total_supply, SupplyExceeded);
+}
+```
+
+### Overflow Protection
+
+```rust
+// All math uses checked operations
+campaign.tokens_sold = campaign.tokens_sold
+  .checked_add(tokens_to_mint)
+  .ok_or(PresaleError::MathOverflow)?;
+```
+
+### PDA Ownership
+
+```rust
+// Treasury owned by Campaign PDA, not artist
+#[account(
+  init,
+  token::authority = campaign,  // PDA is owner
+)]
+pub treasury: Account<'info, TokenAccount>,
+```
+
+**Why this matters:**
+- Artist can't directly drain treasury
+- Withdrawal logic is programmatic
+- Future: Add MOQ gates before allowing withdrawal
+
+## 🌉 Base Comparison
+
+### Metal API → Anchor Program
+
+| Metal Method | Anchor Instruction | Implementation |
+|--------------|-------------------|----------------|
+| `createPresale()` | `initialize_campaign` | Creates campaign PDA + mint |
+| `buyPresale()` | `buy_presale` | USDC transfer + token mint |
+| `getHolder()` | N/A (client-side) | Query token accounts |
+| `createUser()` | N/A (Privy) | Privy wallet generation |
+
+### State Storage
+
+**Base (Metal):**
+```typescript
+// Off-chain database + on-chain tokens
+{
+  presale_id: "abc123",
+  token_address: "0x...",
+  price: 1.5,
+  // ... stored in Postgres/Supabase
+}
+```
+
+**Solana:**
+```rust
+// On-chain account (Campaign PDA)
+pub struct Campaign {
+  authority: Pubkey,
+  campaign_id: String,  // "artist-presale-2024"
+  token_mint: Pubkey,
+  price_per_token_usdc: u64,
+  // ... stored on Solana
+}
+```
+
+**Trade-offs:**
+- ✅ Solana: Full decentralization, no DB dependency
+- ✅ Base: Lower storage costs, flexible schema
+- 🤝 Both: Fast reads, consistent state
+
+### Transaction Cost
+
+| Operation | Base | Solana | Winner |
+|-----------|------|--------|--------|
+| Create campaign | ~$0.03 | ~$0.01 | Solana |
+| Buy tokens | ~$0.02 | ~$0.00002 | **Solana** 🏆 |
+| Withdraw | ~$0.02 | ~$0.00001 | **Solana** 🏆 |
+
+## 📊 Data Flow Example
+
+### Scenario: Artist creates $10k campaign
+
+```
+1. Artist: "Create campaign with 10k tokens at $1 each"
+   
+   initialize_campaign(
+     campaign_id: "indie-album-2024",
+     price: 1.0 USDC,
+     total_supply: 10_000
+   )
+   
+   ↓ Transaction
+   
+   Campaign PDA Created:
+   {
+     campaign_id: "indie-album-2024",
+     price_per_token_usdc: 1_000_000,  // 6 decimals
+     total_supply: 10_000,
+     tokens_sold: 0,
+     usdc_raised: 0,
+     is_active: true
+   }
+
+2. Fan: "Buy $100 worth of tokens"
+   
+   buy_presale(
+     campaign_id: "indie-album-2024",
+     usdc_amount: 100 USDC
+   )
+   
+   ↓ On-chain calculation
+   
+   tokens_to_mint = 100 USDC / 1.0 USDC = 100 tokens
+   
+   ↓ Atomic transfers
+   
+   Transfer: 100 USDC (Fan → Treasury)
+   Mint: 100 tokens (Mint → Fan)
+   
+   ↓ State update
+   
+   Campaign PDA Updated:
+   {
+     tokens_sold: 100,
+     usdc_raised: 100_000_000,  // 100 USDC in lamports
+     ...
+   }
+
+3. 100 fans buy $100 each (total $10k raised)
+   
+   Campaign PDA:
+   {
+     tokens_sold: 10_000,
+     usdc_raised: 10_000_000_000,  // $10k
+     ...
+   }
+
+4. Artist: "Withdraw funds for production"
+   
+   withdraw_funds(
+     amount: 10_000 USDC
+   )
+   
+   ↓ Authority check passes
+   
+   Transfer: 10_000 USDC (Treasury → Artist)
+```
+
+## 🔮 Future Extensions
+
+### Credit Line Integration
+
+```rust
+pub struct Campaign {
+  // ... existing fields
+  
+  // Credit line fields (future)
+  credit_limit: Option<u64>,
+  credit_used: u64,
+  credit_repaid: u64,
+  moq_reached: bool,
+}
+```
+
+### Redemption & Repayment
+
+```rust
+pub fn redeem_and_repay(
+  ctx: Context<RedeemAndRepay>,
+  tokens_to_burn: u64
+) -> Result<()> {
+  // 1. Burn campaign tokens
+  token::burn(/* ... */)?;
+  
+  // 2. Calculate repayment amount
+  let repayment = calculate_repayment(tokens_to_burn);
+  
+  // 3. Stream USDC back to treasury
+  token::transfer(repayment, /* ... */)?;
+  
+  // 4. Update credit line
+  campaign.credit_repaid += repayment;
+  
+  Ok(())
+}
+```
+
+### DeFi Composability
+
+```rust
+// Example: Yield on treasury USDC (MarginFi)
+pub fn deposit_to_yield(
+  ctx: Context<DepositToYield>,
+  amount: u64
+) -> Result<()> {
+  // CPI to MarginFi
+  marginfi::cpi::deposit(
+    ctx.accounts.into(),
+    amount
+  )?;
+  
+  campaign.yield_generating = true;
+  Ok(())
+}
+```
+
+## 🧪 Testing Strategy
+
+### Unit Tests (Anchor)
+```bash
+anchor test
+```
+- Campaign creation
+- Token purchases
+- Supply caps
+- Authority checks
+- Error conditions
+
+### Integration Tests (TypeScript)
+```typescript
+// client/integration.test.ts
+describe("Presale Flow", () => {
+  it("should create campaign and buy tokens", async () => {
+    // Test full lifecycle
+  });
+});
+```
+
+### Fuzz Testing
+```bash
+# Random inputs to find edge cases
+cargo fuzz run presale_fuzz
+```
+
+## 📚 References
+
+- **Anchor Book**: https://book.anchor-lang.com/
+- **Solana Program Library**: https://github.com/solana-labs/solana-program-library
+- **SPL Token**: https://spl.solana.com/token
+- **PDA Derivation**: https://solanacookbook.com/core-concepts/pdas.html
+
+---
+
+**Questions?** See [README.md](./README.md) or open an issue.
+

--- a/solana-adapter/Anchor.toml
+++ b/solana-adapter/Anchor.toml
@@ -6,9 +6,13 @@ skip-lint = false
 
 [programs.devnet]
 superfan_presale = "SuperfnPrsLE11111111111111111111111111111"
+superfan_dao = "SuperfnDAO11111111111111111111111111111111"
+label_subdao = "LabelSubDAO1111111111111111111111111111111"
 
 [programs.localnet]
 superfan_presale = "SuperfnPrsLE11111111111111111111111111111"
+superfan_dao = "SuperfnDAO11111111111111111111111111111111"
+label_subdao = "LabelSubDAO1111111111111111111111111111111"
 
 [registry]
 url = "https://api.apr.dev"

--- a/solana-adapter/Anchor.toml
+++ b/solana-adapter/Anchor.toml
@@ -1,0 +1,22 @@
+[toolchain]
+
+[features]
+resolution = true
+skip-lint = false
+
+[programs.devnet]
+superfan_presale = "SuperfnPrsLE11111111111111111111111111111"
+
+[programs.localnet]
+superfan_presale = "SuperfnPrsLE11111111111111111111111111111"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+cluster = "Devnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+

--- a/solana-adapter/Cargo.toml
+++ b/solana-adapter/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1
+

--- a/solana-adapter/Cargo.toml
+++ b/solana-adapter/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
-    "programs/*"
+    "programs/superfan-presale",
+    "programs/superfan-dao",
+    "programs/label-subdao"
 ]
 resolver = "2"
 

--- a/solana-adapter/DEPLOYMENT.md
+++ b/solana-adapter/DEPLOYMENT.md
@@ -1,0 +1,449 @@
+# Deployment Guide: Superfan Solana Adapter
+
+Complete deployment instructions for the Superfan presale program on Solana.
+
+## 📋 Prerequisites
+
+### 1. Install Solana CLI
+
+```bash
+# Install Solana CLI
+sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+
+# Verify installation
+solana --version
+```
+
+### 2. Install Anchor
+
+```bash
+# Install Anchor CLI
+cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+
+# Verify installation
+anchor --version
+```
+
+### 3. Setup Wallet
+
+```bash
+# Generate new keypair (or use existing)
+solana-keygen new --outfile ~/.config/solana/id.json
+
+# Display your public key
+solana address
+
+# Check balance
+solana balance
+```
+
+## 🌐 DevNet Deployment
+
+### Step 1: Configure Solana CLI
+
+```bash
+# Set cluster to DevNet
+solana config set --url devnet
+
+# Verify configuration
+solana config get
+```
+
+Expected output:
+```
+Config File: ~/.config/solana/cli/config.yml
+RPC URL: https://api.devnet.solana.com
+WebSocket URL: wss://api.devnet.solana.com/
+Keypair Path: ~/.config/solana/id.json
+Commitment: confirmed
+```
+
+### Step 2: Get DevNet SOL
+
+Program deployment costs ~5-10 SOL on DevNet.
+
+```bash
+# Request airdrop (can run multiple times)
+solana airdrop 2
+
+# Verify balance
+solana balance
+```
+
+If airdrop fails:
+- Try again after a few seconds
+- Use Solana Faucet: https://faucet.solana.com/
+
+### Step 3: Build Program
+
+```bash
+cd solana-adapter
+
+# Build the program
+anchor build
+```
+
+This generates:
+- `target/deploy/superfan_presale.so` - Compiled program
+- `target/idl/superfan_presale.json` - Interface definition
+
+**Note the Program ID:**
+```bash
+solana address -k target/deploy/superfan_presale-keypair.json
+```
+
+### Step 4: Update Program ID
+
+Edit `Anchor.toml` and `lib.rs` with your actual Program ID:
+
+**Anchor.toml:**
+```toml
+[programs.devnet]
+superfan_presale = "YOUR_PROGRAM_ID_HERE"
+```
+
+**programs/superfan-presale/src/lib.rs:**
+```rust
+declare_id!("YOUR_PROGRAM_ID_HERE");
+```
+
+Rebuild after updating:
+```bash
+anchor build
+```
+
+### Step 5: Deploy to DevNet
+
+```bash
+# Deploy the program
+anchor deploy --provider.cluster devnet
+```
+
+Expected output:
+```
+Deploying workspace: https://api.devnet.solana.com
+Upgrade authority: YOUR_WALLET_ADDRESS
+Deploying program "superfan_presale"...
+Program path: target/deploy/superfan_presale.so...
+Program Id: YOUR_PROGRAM_ID
+
+Deploy success
+```
+
+### Step 6: Verify Deployment
+
+```bash
+# Check program account exists
+solana program show YOUR_PROGRAM_ID --url devnet
+```
+
+Expected output:
+```
+Program Id: YOUR_PROGRAM_ID
+Owner: BPFLoaderUpgradeab1e11111111111111111111111
+ProgramData Address: ...
+Authority: YOUR_WALLET_ADDRESS
+Last Deployed In Slot: ...
+Data Length: ... bytes
+Balance: ... SOL
+```
+
+### Step 7: Get DevNet USDC
+
+To test presale purchases:
+
+1. Visit https://spl-token-faucet.com/?token-name=USDC
+2. Enter your wallet address
+3. Request 100 USDC
+
+Verify USDC balance:
+```bash
+spl-token accounts
+```
+
+DevNet USDC Mint: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`
+
+### Step 8: Test Program
+
+```bash
+# Run example client
+pnpm client:build
+pnpm client:example
+```
+
+Or run Anchor tests:
+```bash
+anchor test --provider.cluster devnet
+```
+
+## 🔧 Local Testing (Recommended Before DevNet)
+
+Test locally before deploying to DevNet:
+
+### Step 1: Start Local Validator
+
+```bash
+# Terminal 1: Start validator
+solana-test-validator
+```
+
+Keep this running in the background.
+
+### Step 2: Configure for Localhost
+
+```bash
+# Terminal 2: Switch to localhost
+solana config set --url localhost
+
+# Get localnet SOL (free!)
+solana airdrop 10
+```
+
+### Step 3: Deploy Locally
+
+```bash
+anchor build
+anchor deploy --provider.cluster localnet
+
+# Or combined:
+anchor test
+```
+
+This runs:
+1. Builds program
+2. Starts local validator
+3. Deploys program
+4. Runs test suite
+5. Shuts down validator
+
+## 🌟 Client Integration
+
+After deployment, integrate with your frontend:
+
+### 1. Save Program ID
+
+Create `.env.local`:
+```bash
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+NEXT_PUBLIC_PRESALE_PROGRAM_ID=YOUR_PROGRAM_ID
+NEXT_PUBLIC_USDC_MINT=4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU
+```
+
+### 2. Initialize Client
+
+```typescript
+import { SuperfanPresaleClient } from "@/solana-adapter/client/client";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection(
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL!
+);
+
+const programId = new PublicKey(
+  process.env.NEXT_PUBLIC_PRESALE_PROGRAM_ID!
+);
+
+const client = new SuperfanPresaleClient(
+  connection,
+  wallet,
+  programId
+);
+```
+
+### 3. Create Campaign
+
+```typescript
+// API route or admin panel
+await client.createCampaign({
+  campaignId: "artist-name-2024",
+  pricePerTokenUsdc: 1.5,
+  totalSupply: 1_000_000,
+});
+```
+
+### 4. Buy Presale
+
+```typescript
+// User-facing component
+const result = await client.buyPresale({
+  campaignId: "artist-name-2024",
+  usdcAmount: 100,
+});
+```
+
+## 🔐 Production Deployment (Mainnet)
+
+**⚠️ NOT RECOMMENDED YET - Audit Required**
+
+When ready for mainnet:
+
+### Step 1: Security Audit
+
+- [ ] Complete smart contract audit
+- [ ] Penetration testing
+- [ ] Economic attack vectors
+- [ ] Upgrade authority management
+
+### Step 2: Configure Mainnet
+
+```bash
+solana config set --url mainnet-beta
+```
+
+Update `Anchor.toml`:
+```toml
+[programs.mainnet-beta]
+superfan_presale = "YOUR_MAINNET_PROGRAM_ID"
+```
+
+### Step 3: Fund Deployment Wallet
+
+Mainnet deployment costs:
+- Program deployment: ~5-10 SOL
+- Initial testing: ~1 SOL
+- **Total: ~15 SOL recommended**
+
+### Step 4: Deploy
+
+```bash
+anchor build
+anchor deploy --provider.cluster mainnet-beta
+```
+
+### Step 5: Update Frontend
+
+```bash
+# Production environment
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+NEXT_PUBLIC_PRESALE_PROGRAM_ID=YOUR_MAINNET_PROGRAM_ID
+NEXT_PUBLIC_USDC_MINT=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+```
+
+Mainnet USDC Mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+
+## 🐛 Troubleshooting
+
+### Build Errors
+
+**Error: `anchor: command not found`**
+```bash
+# Reinstall Anchor
+cargo install --git https://github.com/coral-xyz/anchor anchor-cli --locked
+```
+
+**Error: `error: package 'anchor-lang v0.30.1' cannot be built`**
+```bash
+# Update Rust
+rustup update stable
+```
+
+### Deployment Errors
+
+**Error: `Insufficient funds`**
+```bash
+# Check balance
+solana balance
+
+# Get more SOL (DevNet)
+solana airdrop 2
+```
+
+**Error: `Program modification is not allowed`**
+```bash
+# Check upgrade authority
+solana program show YOUR_PROGRAM_ID
+
+# Ensure you're using the correct wallet
+solana address
+```
+
+**Error: `Program write to unwritable account`**
+- Rebuild: `anchor build`
+- Verify Program ID matches in `Anchor.toml` and `lib.rs`
+
+### Runtime Errors
+
+**Error: `AccountNotFound`**
+- Campaign doesn't exist
+- Wrong Program ID
+- Campaign ID mismatch
+
+**Error: `InsufficientFunds`**
+- Not enough USDC in buyer wallet
+- Get DevNet USDC: https://spl-token-faucet.com/
+
+**Error: `SupplyExceeded`**
+- Campaign total supply reached
+- Reduce purchase amount
+
+## 📊 Monitoring
+
+### DevNet Explorer
+
+View transactions and accounts:
+- **Solana Explorer**: https://explorer.solana.com/?cluster=devnet
+- **SolanaFM**: https://solana.fm/?cluster=devnet
+
+### Program Logs
+
+```bash
+# Stream logs for your program
+solana logs YOUR_PROGRAM_ID --url devnet
+```
+
+### Account Queries
+
+```bash
+# Get campaign data
+solana account YOUR_CAMPAIGN_PDA --url devnet --output json
+
+# Get token mint info
+spl-token display YOUR_TOKEN_MINT_ADDRESS
+```
+
+## 🔄 Upgrading the Program
+
+Anchor programs are upgradeable by default:
+
+```bash
+# Make changes to lib.rs
+
+# Rebuild
+anchor build
+
+# Upgrade (cheaper than initial deployment)
+anchor upgrade target/deploy/superfan_presale.so --program-id YOUR_PROGRAM_ID
+```
+
+**⚠️ Important:**
+- State layout changes require migration
+- Test upgrades on DevNet first
+- Consider making program immutable for mainnet
+
+## 📚 Resources
+
+- **Solana CLI Reference**: https://docs.solana.com/cli
+- **Anchor Deployment**: https://www.anchor-lang.com/docs/cli
+- **Program Testing**: https://www.anchor-lang.com/docs/testing
+- **Solana DevNet Faucet**: https://faucet.solana.com/
+- **USDC Test Token**: https://spl-token-faucet.com/
+
+## ✅ Deployment Checklist
+
+- [ ] Install Solana CLI
+- [ ] Install Anchor CLI  
+- [ ] Generate/configure wallet
+- [ ] Get DevNet SOL
+- [ ] Build program (`anchor build`)
+- [ ] Update Program ID in code
+- [ ] Deploy to DevNet (`anchor deploy`)
+- [ ] Get DevNet USDC
+- [ ] Test program (`anchor test` or `pnpm client:example`)
+- [ ] Verify on Solana Explorer
+- [ ] Integrate with frontend
+- [ ] Document Program ID for team
+
+---
+
+**Questions?** Open an issue in the main repository.
+

--- a/solana-adapter/METADAO_INTEGRATION.md
+++ b/solana-adapter/METADAO_INTEGRATION.md
@@ -1,0 +1,403 @@
+# Superfan × MetaDAO Integration
+
+> **Building the first consumer futarchy application for music**
+
+## 🎯 Overview
+
+Superfan integrates with MetaDAO's futarchy infrastructure to create a three-layer governance system for funding music labels and artists. This document explains how the programs work together and where MetaDAO's conditional vaults, AMM, and autocrat fit in.
+
+---
+
+## 🏗️ Three-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 1: Superfan DAO (superfan-dao program)               │
+│  • Holds treasury in USDC                                   │
+│  • Uses MetaDAO futarchy for label funding decisions        │
+│  • Pays 5-10% protocol fee to MetaDAO                       │
+└────────────────────┬────────────────────────────────────────┘
+                     │ Funds approved labels
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 2: Label SubDAOs (label-subdao program)              │
+│  • Operate autonomously with own treasury                   │
+│  • Artists submit funding proposals                         │
+│  • Curators approve/reject proposals                        │
+│  • Manage credit lines and repayments                       │
+└────────────────────┬────────────────────────────────────────┘
+                     │ Funds approved artists
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 3: Artist Campaigns (superfan-presale program)       │
+│  • Tokenized presales (USDC → campaign tokens)             │
+│  • Treasury escrow for funds                                │
+│  • Self-repaying credit via fan redemptions                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🔗 MetaDAO Integration Points
+
+### **1. Label Funding Proposals (Layer 1)**
+
+When a curator wants to launch a new label, they submit a proposal via Superfan DAO. This triggers MetaDAO's futarchy system:
+
+#### **Current Flow (Placeholder):**
+```rust
+// superfan-dao/src/lib.rs - propose_label()
+
+pub fn propose_label(
+    ctx: Context<ProposeLabel>,
+    label_name: String,
+    funding_amount: u64,
+    // ...
+) -> Result<()> {
+    // Store proposal
+    let proposal = &mut ctx.accounts.proposal;
+    proposal.label_name = label_name.clone();
+    proposal.funding_amount = funding_amount;
+    
+    // TODO: CPI to MetaDAO Autocrat
+    // proposal.metadao_proposal = ...
+    
+    Ok(())
+}
+```
+
+#### **With MetaDAO Integration:**
+```rust
+use metadao::{
+    autocrat,
+    conditional_vault,
+    amm,
+};
+
+pub fn propose_label(
+    ctx: Context<ProposeLabel>,
+    label_name: String,
+    funding_amount: u64,
+    curator_share_bps: u16,
+) -> Result<()> {
+    // 1. Create MetaDAO proposal
+    let metadao_proposal = autocrat::cpi::create_proposal(
+        CpiContext::new(
+            ctx.accounts.autocrat_program.to_account_info(),
+            autocrat::cpi::accounts::CreateProposal {
+                dao: ctx.accounts.superfan_dao.to_account_info(),
+                proposer: ctx.accounts.proposer.to_account_info(),
+                // ... MetaDAO required accounts
+            }
+        ),
+        autocrat::ProposalParams {
+            // The instruction to execute if proposal passes
+            instruction: create_execute_label_funding_ix(
+                ctx.accounts.superfan_dao.key(),
+                proposal_key,
+                funding_amount
+            ),
+            trading_period_seconds: 3 * 24 * 60 * 60, // 3 days
+        }
+    )?;
+    
+    // 2. MetaDAO automatically creates:
+    //    - Conditional vaults (pass/fail) for USDC
+    //    - AMM with pass/fail markets
+    //    - TWAP oracle tracking
+    
+    // 3. Store Superfan-specific metadata
+    let proposal = &mut ctx.accounts.proposal;
+    proposal.dao = ctx.accounts.superfan_dao.key();
+    proposal.label_name = label_name.clone();
+    proposal.funding_amount = funding_amount;
+    proposal.metadao_proposal = Some(metadao_proposal.key());
+    proposal.pass_market = Some(metadao_proposal.pass_market);
+    proposal.fail_market = Some(metadao_proposal.fail_market);
+    proposal.status = ProposalStatus::Pending;
+    
+    msg!("📋 Label proposal created");
+    msg!("   Trade at: pass_market={}, fail_market={}", 
+        metadao_proposal.pass_market,
+        metadao_proposal.fail_market
+    );
+    
+    Ok(())
+}
+```
+
+#### **What MetaDAO Provides:**
+- ✅ **Conditional Vaults**: Community deposits USDC, gets conditional-on-pass or conditional-on-fail tokens
+- ✅ **AMM Markets**: Users trade pass/fail tokens, revealing belief about label success
+- ✅ **TWAP Oracle**: Manipulation-resistant price aggregation
+- ✅ **Auto-Finalization**: After 3 days, proposal passes if pass_twap > fail_twap
+
+---
+
+### **2. Proposal Execution (Layer 1 → Layer 2)**
+
+After the 3-day trading period, MetaDAO finalizes the proposal:
+
+```rust
+// superfan-dao/src/lib.rs - execute_label_funding()
+
+pub fn execute_label_funding(
+    ctx: Context<ExecuteLabelFunding>,
+) -> Result<()> {
+    let proposal = &ctx.accounts.proposal;
+    
+    // 1. Verify MetaDAO proposal passed
+    let metadao_proposal = autocrat::get_proposal(
+        proposal.metadao_proposal.unwrap()
+    )?;
+    
+    require!(
+        metadao_proposal.status == autocrat::ProposalStatus::Passed,
+        SuperfanError::ProposalNotPassed
+    );
+    
+    // 2. MetaDAO has already:
+    //    - Finalized pass conditional vault (believers get USDC + rewards)
+    //    - Reverted fail conditional vault (non-believers get USDC back)
+    
+    // 3. Create Label SubDAO with approved funding
+    let label = &mut ctx.accounts.label;
+    label.name = proposal.label_name.clone();
+    label.initial_funding = proposal.funding_amount;
+    // ... initialize label
+    
+    // 4. Transfer funds from DAO treasury to Label treasury
+    transfer_tokens(
+        ctx.accounts.dao_treasury,
+        ctx.accounts.label_treasury,
+        proposal.funding_amount
+    )?;
+    
+    msg!("🎉 Label funded: {} USDC", proposal.funding_amount);
+    
+    Ok(())
+}
+```
+
+---
+
+### **3. User Experience: Trading on Label Success**
+
+#### **For Community Members:**
+
+**What they see:**
+```
+🎵 New Label Proposal: Delacour Recordings
+   Requested: $50,000
+   Curator: @delacour_music
+   Vision: "Championing indie electronic producers"
+   
+   Market Prediction:
+   ✅ 63% believe this label will succeed
+   ❌ 37% believe it will not
+   
+   [Back This Label] [Trade Prediction]
+```
+
+**What's happening behind the scenes:**
+```typescript
+// User clicks "Back This Label"
+await metadao.conditionalVault.deposit({
+  vault: proposal.pass_vault,
+  amount: 100_000_000, // $100 USDC
+  user: userWallet
+});
+
+// User receives conditional-on-pass tokens
+// Can trade these on MetaDAO's AMM if they want to adjust position
+```
+
+#### **For Label Curators:**
+
+**What they see:**
+```
+📊 Your Label Proposal Status
+   
+   Delacour Recordings
+   Funding: $50,000 | Status: Active Trading
+   
+   Community Belief: 63% Pass | 37% Fail
+   Time Remaining: 1d 6h 23m
+   
+   Top Supporters:
+   • alice.eth: $1,000 (Pass)
+   • bob.sol: $500 (Pass)
+   • charlie.base: $200 (Fail)
+```
+
+---
+
+## 💰 Economics: Option A (Treasury Partnership)
+
+### **Revenue Share Model**
+
+```
+Repayment Flow:
+─────────────────────────────────────────────────────────
+
+Artist repays credit
+        │
+        ▼
+Label Treasury (Layer 2)
+        │
+        ├─ 80-90% → Label keeps (curator share)
+        │
+        └─ 10-20% → Superfan DAO Treasury
+                           │
+                           ├─ 90-95% → Superfan keeps
+                           │
+                           └─ 5-10% → MetaDAO Protocol Fee
+```
+
+### **Example:**
+
+```
+Artist repays: $10,000
+└─ Label keeps: $8,000 (80%)
+└─ Superfan receives: $2,000 (20%)
+   └─ Superfan keeps: $1,800 (90%)
+   └─ MetaDAO receives: $200 (10%) ← Protocol fee
+```
+
+Implemented in `superfan-dao/src/lib.rs`:
+
+```rust
+pub fn record_label_repayment(
+    ctx: Context<RecordRepayment>,
+    amount: u64,
+) -> Result<()> {
+    // Transfer from label to DAO
+    transfer_tokens(/* ... */)?;
+    
+    // Calculate MetaDAO fee
+    let dao = &ctx.accounts.dao;
+    let protocol_fee = (amount as u128)
+        .checked_mul(dao.metadao_fee_bps as u128) // e.g., 500 bps = 5%
+        .unwrap()
+        .checked_div(10000)
+        .unwrap() as u64;
+    
+    msg!("Protocol fee to MetaDAO: {} USDC", protocol_fee);
+    
+    Ok(())
+}
+```
+
+---
+
+## 🚀 Initial Funding: Token Launch on MetaDAO
+
+Superfan will bootstrap its treasury via a **token launch on MetaDAO's platform**:
+
+### **Launch Flow:**
+
+1. **Create $SUPERFAN token** on Solana
+2. **Use MetaDAO's token launch infrastructure**
+   - Bonding curve or fixed-price sale
+   - Proceeds go to Superfan DAO treasury (USDC)
+3. **DAO treasury is now funded** to begin financing labels
+
+### **Example Launch:**
+
+```
+$SUPERFAN Token Launch
+─────────────────────────
+Supply: 100,000,000 $SUPERFAN
+Price: $0.10 per token
+Raise Target: $1,000,000 USDC
+
+Proceeds:
+• $950,000 → Superfan DAO Treasury (95%)
+• $50,000 → MetaDAO Protocol Fee (5%)
+
+Superfan DAO can now fund 10-20 labels @ $50k each
+```
+
+---
+
+## 🔧 Implementation Checklist
+
+### **Phase 1: Program Integration** ✅ (Current)
+- [x] `superfan-dao` program with proposal system
+- [x] `label-subdao` program with artist credit lines
+- [x] `superfan-presale` program for artist campaigns
+- [ ] **TODO: Add MetaDAO CPIs to propose_label()**
+- [ ] **TODO: Add MetaDAO verification to execute_label_funding()**
+
+### **Phase 2: MetaDAO Dependencies** 🔄 (Next)
+- [ ] Add MetaDAO programs as Anchor dependencies
+- [ ] Implement conditional vault CPIs
+- [ ] Implement AMM read operations (for TWAP)
+- [ ] Implement autocrat proposal lifecycle
+
+### **Phase 3: Client SDK** 📝 (After Phase 2)
+- [ ] TypeScript client for Superfan DAO
+- [ ] MetaDAO market integration (read pass/fail prices)
+- [ ] User deposit flow (conditional vaults)
+- [ ] Curator dashboard (proposal status)
+
+### **Phase 4: Frontend UX** 🎨 (Final)
+- [ ] Proposal creation form
+- [ ] Live market view (pass/fail %)
+- [ ] Trading interface
+- [ ] Label dashboard
+- [ ] Artist proposal flow
+
+---
+
+## 📚 MetaDAO Resources
+
+### **Documentation:**
+- **MetaDAO Docs**: https://docs.themetadao.org/
+- **Conditional Vaults**: https://docs.themetadao.org/conditional-vaults
+- **AMM (OpenbookTWAP)**: https://docs.themetadao.org/amm
+- **Autocrat**: https://docs.themetadao.org/autocrat
+
+### **Program IDs (DevNet):**
+```rust
+// TODO: Get actual MetaDAO DevNet program IDs
+pub const METADAO_CONDITIONAL_VAULT: Pubkey = ...;
+pub const METADAO_AMM: Pubkey = ...;
+pub const METADAO_AUTOCRAT: Pubkey = ...;
+```
+
+### **Example CPIs:**
+See MetaDAO's example integrations:
+- https://github.com/metadaoproject/futarchy/examples
+
+---
+
+## 🤝 Partnership Benefits
+
+### **For Superfan:**
+- ✅ Battle-tested futarchy infrastructure
+- ✅ Instant credibility ("Built on MetaDAO")
+- ✅ Shared liquidity (MetaDAO traders participate)
+- ✅ 3-week integration vs. 3-month rebuild
+
+### **For MetaDAO:**
+- ✅ First consumer-facing use case
+- ✅ Music industry validation (multi-billion TAM)
+- ✅ UX innovation (crypto-silent futarchy)
+- ✅ Protocol fee revenue from Superfan treasury
+- ✅ Case study for future vertical apps
+
+---
+
+## 🎯 Next Steps
+
+1. **Connect with MetaDAO team** - Discuss partnership structure
+2. **Add MetaDAO dependencies** - Import programs as Anchor deps
+3. **Implement CPIs** - propose_label() → autocrat::create_proposal()
+4. **Build TypeScript SDK** - Wrap MetaDAO + Superfan programs
+5. **Launch pilot proposal** - Test with real futarchy markets on DevNet
+
+---
+
+**Ready to build the first consumer futarchy application. Let's turn belief into capital. 🎵**
+

--- a/solana-adapter/METADAO_INTEGRATION.md
+++ b/solana-adapter/METADAO_INTEGRATION.md
@@ -8,33 +8,48 @@ Superfan integrates with MetaDAO's futarchy infrastructure to create a three-lay
 
 ---
 
-## 🏗️ Three-Layer Architecture
+## 🏗️ Two-Layer Architecture (Fan-Owned Labels)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  Layer 1: Superfan DAO (superfan-dao program)               │
 │  • Holds treasury in USDC                                   │
-│  • Uses MetaDAO futarchy for label funding decisions        │
+│  • Uses MetaDAO futarchy: "Which labels to fund?"           │
+│  • Creates labels + issues label tokens to fans             │
 │  • Pays 5-10% protocol fee to MetaDAO                       │
 └────────────────────┬────────────────────────────────────────┘
                      │ Funds approved labels
+                     │ Mints label governance tokens
                      ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  Layer 2: Label SubDAOs (label-subdao program)              │
-│  • Operate autonomously with own treasury                   │
-│  • Artists submit funding proposals                         │
-│  • Curators approve/reject proposals                        │
-│  • Manage credit lines and repayments                       │
-└────────────────────┬────────────────────────────────────────┘
-                     │ Funds approved artists
-                     ▼
-┌─────────────────────────────────────────────────────────────┐
-│  Layer 3: Artist Campaigns (superfan-presale program)       │
-│  • Tokenized presales (USDC → campaign tokens)             │
-│  • Treasury escrow for funds                                │
-│  • Self-repaying credit via fan redemptions                 │
+│  Layer 2: Fan-Owned Labels (label-subdao program)           │
+│  • Fans own label tokens (50% curator, 40% futarchy, 10% DAO)│
+│  • Token holders govern via NESTED futarchy                  │
+│  • Artists submit proposals → Token holders vote            │
+│  • Credit lines created for passing proposals               │
+│  • Repayments → Treasury → Token value ↑                    │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Artist Campaigns (superfan-presale program)        │   │
+│  │  • Tokenized presales (USDC → campaign tokens)     │   │
+│  │  • Self-repaying credit via fan redemptions        │   │
+│  └─────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────┘
 ```
+
+## 💡 Why Two Layers Is Better
+
+**OLD (3 layers):** DAO → Label Curator → Artist → Fans  
+❌ Curator is bottleneck  
+❌ Fans only participate at artist level  
+❌ No label ownership for fans
+
+**NEW (2 layers):** DAO → Label Token Holders ← Fans  
+✅ Fans own the label  
+✅ Fans govern which artists get funded  
+✅ Fans benefit from ALL artist success  
+✅ No curator gatekeeping  
+✅ **Double futarchy** (DAO level + Label level)
 
 ---
 
@@ -232,37 +247,45 @@ await metadao.conditionalVault.deposit({
 
 ---
 
-## 💰 Economics: Option A (Treasury Partnership)
+## 💰 Economics: Fan-Owned Label Model
 
-### **Revenue Share Model**
+### **Repayment Flow (Cleaner)**
 
 ```
 Repayment Flow:
 ─────────────────────────────────────────────────────────
 
-Artist repays credit
+Fans redeem rewards → Artist repays
         │
         ▼
-Label Treasury (Layer 2)
+Label Treasury (Owned by token holders)
         │
-        ├─ 80-90% → Label keeps (curator share)
+        ├─ 90-95% → Stays in label treasury
+        │             └─ Label token value ↑
+        │             └─ All token holders benefit
         │
-        └─ 10-20% → Superfan DAO Treasury
-                           │
-                           ├─ 90-95% → Superfan keeps
-                           │
-                           └─ 5-10% → MetaDAO Protocol Fee
+        └─ 5-10% → Superfan DAO Treasury
+                      │
+                      └─ 5-10% of that → MetaDAO Protocol Fee
 ```
 
 ### **Example:**
 
 ```
 Artist repays: $10,000
-└─ Label keeps: $8,000 (80%)
-└─ Superfan receives: $2,000 (20%)
-   └─ Superfan keeps: $1,800 (90%)
-   └─ MetaDAO receives: $200 (10%) ← Protocol fee
+└─ Label treasury: $9,500 (95%)
+   └─ Treasury grows → $DELACOUR token backed by more USDC
+   └─ All $DELACOUR holders benefit (fans who believed)
+   
+└─ Superfan DAO: $500 (5%)
+   └─ Protocol fee to MetaDAO: $50 (10% of $500)
 ```
+
+**Why This Works:**
+- Fans own label tokens → direct benefit from artist success
+- No curator taking 80% cut
+- Treasury growth benefits ALL token holders
+- Simple, transparent, fair
 
 Implemented in `superfan-dao/src/lib.rs`:
 
@@ -322,31 +345,35 @@ Superfan DAO can now fund 10-20 labels @ $50k each
 
 ## 🔧 Implementation Checklist
 
-### **Phase 1: Program Integration** ✅ (Current)
-- [x] `superfan-dao` program with proposal system
-- [x] `label-subdao` program with artist credit lines
+### **Phase 1: Program Architecture** ✅ (Current - SIMPLIFIED)
+- [x] `superfan-dao` program with futarchy for labels
+- [x] `label-subdao` program with futarchy for artists (NO CURATOR GATEKEEPING)
 - [x] `superfan-presale` program for artist campaigns
+- [x] Label token minting (50% curator, 40% futarchy winners, 10% DAO)
+- [x] Removed curator approval bottleneck
 - [ ] **TODO: Add MetaDAO CPIs to propose_label()**
-- [ ] **TODO: Add MetaDAO verification to execute_label_funding()**
+- [ ] **TODO: Add MetaDAO CPIs to submit_artist_proposal()**
+- [ ] **TODO: Add MetaDAO verification to execute_*_funding()**
 
 ### **Phase 2: MetaDAO Dependencies** 🔄 (Next)
 - [ ] Add MetaDAO programs as Anchor dependencies
-- [ ] Implement conditional vault CPIs
+- [ ] Implement conditional vault CPIs (both layers)
 - [ ] Implement AMM read operations (for TWAP)
-- [ ] Implement autocrat proposal lifecycle
+- [ ] Implement autocrat proposal lifecycle (nested futarchy)
 
 ### **Phase 3: Client SDK** 📝 (After Phase 2)
 - [ ] TypeScript client for Superfan DAO
+- [ ] Label token holder dashboard
 - [ ] MetaDAO market integration (read pass/fail prices)
-- [ ] User deposit flow (conditional vaults)
-- [ ] Curator dashboard (proposal status)
+- [ ] User deposit flow (conditional vaults - buy label tokens via futarchy)
 
 ### **Phase 4: Frontend UX** 🎨 (Final)
-- [ ] Proposal creation form
-- [ ] Live market view (pass/fail %)
-- [ ] Trading interface
-- [ ] Label dashboard
-- [ ] Artist proposal flow
+- [ ] Label proposal form (curators)
+- [ ] Label futarchy market view (fans vote)
+- [ ] Artist proposal form (artists)
+- [ ] Artist futarchy market view (label token holders vote)
+- [ ] Label token holder dashboard (portfolio view)
+- [ ] Treasury value tracking
 
 ---
 

--- a/solana-adapter/QUICKSTART.md
+++ b/solana-adapter/QUICKSTART.md
@@ -1,0 +1,303 @@
+# Superfan Solana Adapter - Quick Start
+
+**Get up and running in 5 minutes.**
+
+## 🚀 TL;DR
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build program
+anchor build
+
+# Deploy to DevNet
+anchor deploy --provider.cluster devnet
+
+# Run example
+pnpm client:example
+```
+
+## 📦 What You Get
+
+After following this guide, you'll have:
+
+✅ Superfan presale program deployed to Solana DevNet  
+✅ TypeScript client ready to integrate  
+✅ Working example of creating campaigns and buying tokens  
+✅ Privy integration template for your frontend  
+
+## 🏁 Step-by-Step Setup
+
+### 1. Prerequisites (5 min)
+
+```bash
+# Install Solana CLI
+sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+
+# Install Anchor
+cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+
+# Verify installations
+solana --version
+anchor --version
+```
+
+### 2. Create Wallet (2 min)
+
+```bash
+# Generate new keypair
+solana-keygen new
+
+# Save this - you'll need it!
+solana address
+
+# Configure for DevNet
+solana config set --url devnet
+
+# Get free DevNet SOL
+solana airdrop 2
+```
+
+### 3. Build & Deploy (3 min)
+
+```bash
+cd solana-adapter
+
+# Install Node dependencies
+pnpm install
+
+# Build the Rust program
+anchor build
+
+# Deploy to DevNet
+anchor deploy --provider.cluster devnet
+```
+
+**Copy your Program ID** - it's shown in the deploy output!
+
+### 4. Get Test USDC (1 min)
+
+Visit: https://spl-token-faucet.com/?token-name=USDC
+
+1. Paste your wallet address
+2. Click "Request USDC"
+3. Confirm with `spl-token accounts`
+
+### 5. Run Example (1 min)
+
+```bash
+# Build TypeScript client
+pnpm client:build
+
+# Run the example
+pnpm client:example
+```
+
+You should see:
+```
+🚀 Superfan Solana Presale Example
+📍 Wallet: <your-address>
+💰 Balance: 2 SOL
+
+📝 Creating campaign...
+✅ Campaign created!
+   TX: <transaction-signature>
+
+💳 Buying presale tokens...
+✅ Purchase complete!
+   USDC spent: $10
+   Tokens minted: 6.666666
+
+✨ Example complete!
+```
+
+## 🎉 You're Done!
+
+### View Your Transactions
+
+Check Solana Explorer:
+```
+https://explorer.solana.com/address/<YOUR_PROGRAM_ID>?cluster=devnet
+```
+
+### Next Steps
+
+1. **Integrate with Frontend**: See [client/privy-integration.ts](./client/privy-integration.ts)
+2. **Read Architecture**: Check [ARCHITECTURE.md](./ARCHITECTURE.md)
+3. **Deploy for Real**: Follow [DEPLOYMENT.md](./DEPLOYMENT.md)
+
+## 🔥 Frontend Integration (10 min)
+
+### Add to Your Next.js App
+
+**1. Copy client files:**
+```bash
+cp -r solana-adapter/client/* app/solana-presale/
+```
+
+**2. Install dependencies:**
+```bash
+pnpm add @solana/web3.js @coral-xyz/anchor @solana/spl-token
+```
+
+**3. Create API route:**
+
+File: `app/api/presale/buy/route.ts`
+```typescript
+import { SuperfanPresaleClient } from "@/solana-presale/client";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+export async function POST(request: Request) {
+  const { campaignId, usdcAmount } = await request.json();
+  
+  const connection = new Connection(process.env.SOLANA_RPC_URL!);
+  const programId = new PublicKey(process.env.PRESALE_PROGRAM_ID!);
+  
+  const client = new SuperfanPresaleClient(
+    connection,
+    wallet, // Use Privy wallet here
+    programId
+  );
+  
+  const result = await client.buyPresale({
+    campaignId,
+    usdcAmount,
+  });
+  
+  return Response.json(result);
+}
+```
+
+**4. Create UI component:**
+
+File: `components/solana-presale-button.tsx`
+```typescript
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function SolanaPresaleButton({ 
+  campaignId, 
+  amount 
+}: { 
+  campaignId: string; 
+  amount: number; 
+}) {
+  const [loading, setLoading] = useState(false);
+  
+  const handleBuy = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/presale/buy", {
+        method: "POST",
+        body: JSON.stringify({ campaignId, usdcAmount: amount }),
+      });
+      const result = await res.json();
+      alert(`Success! Minted ${result.campaignTokensMinted} tokens`);
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+  return (
+    <Button onClick={handleBuy} disabled={loading}>
+      {loading ? "Processing..." : `Buy $${amount} USDC`}
+    </Button>
+  );
+}
+```
+
+**5. Add to existing presale banner:**
+
+File: `components/presale-banner.tsx`
+```typescript
+import { SolanaPresaleButton } from "./solana-presale-button";
+
+// In your component:
+<SolanaPresaleButton 
+  campaignId="phat-trax-2024" 
+  amount={100} 
+/>
+```
+
+## 📱 Privy Solana Setup
+
+**1. Enable Solana in Privy:**
+
+Dashboard → Settings → Login Methods → Enable Solana
+
+**2. Update your Privy config:**
+
+```typescript
+// app/providers.tsx
+<PrivyProvider
+  appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID!}
+  config={{
+    // ... existing config
+    supportedChains: [
+      base,
+      solana, // Add Solana
+    ],
+  }}
+>
+```
+
+**3. Get user's Solana wallet:**
+
+```typescript
+import { usePrivy } from "@privy-io/react-auth";
+
+function MyComponent() {
+  const { user } = usePrivy();
+  
+  const solanaWallet = user?.linkedAccounts.find(
+    account => account.type === "wallet" && account.chainType === "solana"
+  );
+  
+  console.log("Solana address:", solanaWallet?.address);
+}
+```
+
+## 🐛 Troubleshooting
+
+### "anchor: command not found"
+```bash
+cargo install --git https://github.com/coral-xyz/anchor anchor-cli --locked
+```
+
+### "Insufficient funds"
+```bash
+solana airdrop 2
+```
+
+### "Program modification not allowed"
+```bash
+# Rebuild with correct Program ID
+anchor build
+```
+
+### "AccountNotFound"
+- Campaign doesn't exist
+- Check campaign ID matches
+- Verify program deployed correctly
+
+## 📚 Learn More
+
+- **Full README**: [README.md](./README.md)
+- **Architecture Deep Dive**: [ARCHITECTURE.md](./ARCHITECTURE.md)
+- **Production Deployment**: [DEPLOYMENT.md](./DEPLOYMENT.md)
+
+## 💬 Need Help?
+
+1. Check the [troubleshooting section](#-troubleshooting)
+2. Review [DEPLOYMENT.md](./DEPLOYMENT.md) for detailed steps
+3. Open an issue in the main repo
+
+---
+
+**Built with ❤️ for artists and their superfans**
+
+🎸 Now go launch some campaigns! 🚀
+

--- a/solana-adapter/README.md
+++ b/solana-adapter/README.md
@@ -1,0 +1,356 @@
+# Superfan Solana Adapter
+
+> **Belief-backed credit on Solana**  
+> Port of Superfan's tokenized presale system from Base (EVM) to Solana
+
+## 📋 Overview
+
+The Superfan Solana Adapter replicates the core presale mechanism from our Base contracts using Solana-native constructs. It demonstrates that our **fan-powered liquidity → self-repaying credit** model works seamlessly on Solana's high-throughput, low-fee architecture.
+
+This adapter enables:
+- ✅ **Tokenized presales** - Artists raise funds by selling campaign tokens
+- ✅ **USDC settlements** - Fans back campaigns with USDC (DevNet for testing)
+- ✅ **Automated token minting** - Campaign tokens distributed on purchase
+- ✅ **Privy wallet abstraction** - Zero-crypto UX for fans
+- ✅ **Cross-chain validation** - Proves our model is chain-agnostic
+
+## 🏗️ Architecture
+
+### Concept Mapping: Base → Solana
+
+| Concept | Base Implementation | Solana Equivalent |
+|---------|-------------------|-------------------|
+| **Campaign Tokens** | ERC-1155 (via Metal) | SPL Token mints |
+| **Presale Escrow** | Solidity contracts | PDAs holding USDC |
+| **Settlement Token** | USDC (ERC-20) | SPL-USDC (DevNet) |
+| **Wallet Layer** | Privy (EVM) | Privy (Solana embedded) |
+| **State Storage** | Contract storage | Anchor account structs |
+| **Token Operations** | Metal SDK | Anchor CPI (token::mint_to) |
+
+### Program Structure
+
+```
+solana-adapter/
+├── programs/
+│   └── superfan-presale/        # Anchor program (Rust)
+│       └── src/lib.rs           # Core presale logic
+├── client/
+│   ├── client.ts                # TypeScript SDK
+│   ├── privy-integration.ts     # Privy wallet examples
+│   ├── types.ts                 # Type definitions
+│   └── example.ts               # Usage examples
+├── Anchor.toml                  # Anchor configuration
+├── package.json                 # Node dependencies
+└── README.md                    # This file
+```
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+```bash
+# Install Rust & Solana
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+sh -c "$(curl -sSfL https://release.solana.com/stable/install)"
+
+# Install Anchor
+cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+
+# Install Node dependencies
+pnpm install
+```
+
+### 1. Build the Program
+
+```bash
+cd solana-adapter
+anchor build
+```
+
+This generates:
+- `target/deploy/superfan_presale.so` - Program binary
+- `target/idl/superfan_presale.json` - IDL for client
+
+### 2. Deploy to DevNet
+
+```bash
+# Configure Solana CLI for DevNet
+solana config set --url devnet
+
+# Generate a wallet (or use existing)
+solana-keygen new
+
+# Get DevNet SOL for deployment
+solana airdrop 2
+
+# Deploy the program
+anchor deploy --provider.cluster devnet
+```
+
+**Save your Program ID** - you'll need it for client configuration.
+
+### 3. Get DevNet USDC
+
+To test presale purchases, you need DevNet USDC:
+
+1. Visit: https://spl-token-faucet.com/?token-name=USDC
+2. Enter your wallet address
+3. Click "Request USDC"
+
+DevNet USDC Mint: `4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU`
+
+### 4. Run Example Client
+
+```bash
+# Build TypeScript client
+pnpm client:build
+
+# Run example
+pnpm client:example
+```
+
+This will:
+- Create a test campaign
+- Display campaign stats
+- Purchase tokens with USDC
+- Show updated funding
+
+## 💻 Usage
+
+### TypeScript Client
+
+```typescript
+import { Connection, PublicKey } from "@solana/web3.js";
+import { SuperfanPresaleClient } from "./client/client";
+
+// Initialize
+const connection = new Connection("https://api.devnet.solana.com");
+const programId = new PublicKey("YOUR_PROGRAM_ID");
+const client = new SuperfanPresaleClient(connection, wallet, programId);
+
+// Create campaign
+await client.createCampaign({
+  campaignId: "artist-presale-2024",
+  pricePerTokenUsdc: 1.5,        // $1.50 per token
+  totalSupply: 1_000_000,        // 1M tokens max
+  lockDuration: 0,               // No lock period
+});
+
+// Buy tokens
+const result = await client.buyPresale({
+  campaignId: "artist-presale-2024",
+  usdcAmount: 100,               // $100 USDC
+});
+
+console.log("Tokens minted:", result.campaignTokensMinted);
+```
+
+### Privy Integration
+
+```typescript
+import { PrivySuperfanPresaleClient } from "./client/privy-integration";
+
+// Initialize with Privy credentials
+const client = new PrivySuperfanPresaleClient({
+  privyAppId: process.env.NEXT_PUBLIC_PRIVY_APP_ID,
+  privyAppSecret: process.env.PRIVY_APP_SECRET,
+  solanaRpcUrl: "https://api.devnet.solana.com",
+  programId: "YOUR_PROGRAM_ID",
+});
+
+// Buy tokens for user (wallet abstracted by Privy)
+await client.buyPresaleForUser(
+  user.id,              // Privy user ID
+  "artist-presale-2024",
+  100                   // $100 USDC
+);
+```
+
+See [`client/privy-integration.ts`](./client/privy-integration.ts) for Next.js API route and React component examples.
+
+## 🔑 Program Instructions
+
+### 1. `initialize_campaign`
+
+Creates a new presale campaign with:
+- Campaign state account (PDA)
+- Campaign token mint (SPL token)
+- Treasury account (holds USDC)
+
+**Accounts:**
+- `campaign` - PDA storing campaign metadata
+- `campaign_token_mint` - SPL token mint for this campaign
+- `treasury` - Token account holding USDC
+- `authority` - Campaign creator (signer)
+
+**Args:**
+- `campaign_id: String` - Unique identifier (max 50 chars)
+- `price_per_token_usdc: u64` - Price in USDC lamports (6 decimals)
+- `total_supply: Option<u64>` - Max tokens to mint (None = unlimited)
+- `lock_duration: Option<i64>` - Lock period in seconds
+
+### 2. `buy_presale`
+
+Purchases campaign tokens with USDC.
+
+**Atomic flow:**
+1. Transfer USDC: buyer → treasury
+2. Mint campaign tokens → buyer
+3. Update campaign stats
+
+**Accounts:**
+- `campaign` - Campaign state PDA
+- `buyer` - Token purchaser (signer)
+- `buyer_usdc_account` - Buyer's USDC token account
+- `buyer_token_account` - Buyer's campaign token account (created if needed)
+
+**Args:**
+- `usdc_amount: u64` - USDC to spend (lamports, 6 decimals)
+
+### 3. `withdraw_funds`
+
+Withdraws USDC from treasury (authority only).
+
+**Args:**
+- `amount: u64` - USDC to withdraw (lamports)
+
+### 4. `close_campaign`
+
+Closes campaign, preventing new purchases (authority only).
+
+## 🧪 Testing
+
+### Run Anchor Tests
+
+```bash
+anchor test
+```
+
+This spins up a local validator and runs the test suite.
+
+### Manual Testing on DevNet
+
+1. Deploy program to DevNet
+2. Create a campaign: `pnpm client:example`
+3. Get DevNet USDC: https://spl-token-faucet.com/
+4. Purchase tokens
+5. Verify balance in Solana Explorer
+
+## 📊 Comparison: Base vs. Solana
+
+### What's the Same
+
+✅ **User flow** - Fans back campaigns → receive tokens  
+✅ **Price discovery** - Price per token set by artist  
+✅ **Supply caps** - Optional max token supply  
+✅ **Wallet abstraction** - Privy handles all wallet complexity  
+✅ **USDC settlements** - Same stablecoin, different chain
+
+### What's Different
+
+| Aspect | Base | Solana |
+|--------|------|--------|
+| **Token standard** | ERC-1155 (via Metal) | SPL Token |
+| **Account model** | EVM storage slots | Account-based (PDAs) |
+| **Transaction cost** | ~$0.01-0.05 | ~$0.00001 |
+| **Throughput** | ~10-50 TPS | ~3,000 TPS |
+| **Finality** | ~2 seconds | ~400ms |
+| **Wallet format** | 0x... (Ethereum) | Base58 (Solana) |
+
+### Implementation Notes
+
+#### Token Minting
+- **Base**: Metal SDK handles mint via server API
+- **Solana**: Direct CPI to `token::mint_to`
+
+#### Escrow
+- **Base**: Smart contract holds USDC
+- **Solana**: PDA-owned token account
+
+#### Price Calculation
+- **Base**: Handled off-chain by Metal
+- **Solana**: On-chain math in `buy_presale` instruction
+
+## 🔐 Security Considerations
+
+### Program Authority
+- Only campaign `authority` can withdraw funds or close campaign
+- PDA-based authority prevents unauthorized access
+
+### Supply Caps
+- Optional `total_supply` enforced on-chain
+- Prevents over-minting
+
+### USDC Handling
+- All USDC transfers atomic (transaction succeeds or reverts entirely)
+- Treasury controlled by campaign PDA
+
+### Recommended Audits
+- [ ] Anchor security review
+- [ ] Token mint authority verification
+- [ ] Treasury withdrawal logic
+- [ ] Overflow/underflow checks (handled by Rust)
+
+## 🌐 Mainnet Deployment
+
+**⚠️ DevNet Only for Now**
+
+Before mainnet:
+1. Complete security audit
+2. Add MOQ/milestone gates
+3. Implement credit line repayment
+4. Test with real USDC on DevNet
+5. Gradual rollout with monitoring
+
+Update `Anchor.toml` for mainnet:
+```toml
+[programs.mainnet-beta]
+superfan_presale = "YOUR_MAINNET_PROGRAM_ID"
+
+[provider]
+cluster = "Mainnet"
+```
+
+## 🛣️ Roadmap
+
+### ✅ Phase 1: Core Presale (Complete)
+- Campaign creation
+- Token minting
+- USDC purchases
+- Privy integration
+
+### 🔄 Phase 2: Credit System (Future)
+- MOQ tracking
+- Escrow release gates
+- Credit line calculation
+- Repayment streams
+
+### 🔮 Phase 3: Cross-Chain Sync (Future)
+- Event indexing
+- Base ↔ Solana state sync
+- Unified campaign dashboard
+
+## 📚 Resources
+
+- **Anchor Docs**: https://www.anchor-lang.com/
+- **Solana Cookbook**: https://solanacookbook.com/
+- **Privy Solana Guide**: https://docs.privy.io/guide/guides/solana
+- **SPL Token Docs**: https://spl.solana.com/token
+- **Metal Docs**: https://docs.metal.build/
+
+## 🤝 Contributing
+
+This adapter is part of Superfan's Colosseum hackathon submission. For questions or improvements:
+
+1. Open an issue describing the enhancement
+2. Reference this README in your PR
+3. Ensure all tests pass: `anchor test`
+
+## 📄 License
+
+See main repository license.
+
+---
+
+**Built with ❤️ for artists and their superfans**
+

--- a/solana-adapter/client/client.ts
+++ b/solana-adapter/client/client.ts
@@ -221,10 +221,17 @@ export class SuperfanPresaleClient {
       })
       .rpc();
 
-    // Calculate tokens minted using BN integer arithmetic
+    // Calculate tokens minted with fixed-point precision
+    // Use 6 decimals to match USDC precision
+    const SCALE = new BN(1_000_000);
     const usdcBN = new BN(usdcLamports);
-    const tokensMintedBN = usdcBN.div(campaign.pricePerTokenUsdc);
-    const tokensMinted = tokensMintedBN.toNumber();
+    const priceBN = new BN(campaign.pricePerTokenUsdc);
+    
+    // scaled = (usdcLamports * SCALE) / pricePerTokenUsdc
+    const scaledTokens = usdcBN.mul(SCALE).div(priceBN);
+    
+    // Convert to decimal representation: integer part + fractional part
+    const tokensMinted = scaledTokens.toNumber() / SCALE.toNumber();
 
     this.logger.info("Presale purchase complete", {
       signature: tx,

--- a/solana-adapter/client/client.ts
+++ b/solana-adapter/client/client.ts
@@ -1,0 +1,288 @@
+import {
+  Connection,
+  PublicKey,
+  Keypair,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  Transaction,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddress,
+} from "@solana/spl-token";
+import { Program, AnchorProvider, BN } from "@coral-xyz/anchor";
+import type { SuperfanPresale } from "../target/types/superfan_presale";
+import idl from "../target/idl/superfan_presale.json";
+import {
+  CreateCampaignParams,
+  BuyPresaleParams,
+  BuyPresaleResult,
+  CampaignAccount,
+  CampaignStats,
+} from "./types";
+
+/**
+ * Superfan Presale Client
+ * 
+ * High-level TypeScript client for interacting with the Superfan presale program.
+ * Designed to work seamlessly with Privy's wallet abstraction.
+ * 
+ * Usage:
+ * ```ts
+ * const client = new SuperfanPresaleClient(connection, wallet, PROGRAM_ID);
+ * 
+ * // Create a campaign
+ * await client.createCampaign({
+ *   campaignId: "artist-presale-2024",
+ *   pricePerTokenUsdc: 1.5,
+ *   totalSupply: 1000000
+ * });
+ * 
+ * // Buy tokens
+ * await client.buyPresale({
+ *   campaignId: "artist-presale-2024",
+ *   usdcAmount: 100
+ * });
+ * ```
+ */
+export class SuperfanPresaleClient {
+  private program: Program<SuperfanPresale>;
+  private connection: Connection;
+  private wallet: any; // Privy wallet or Keypair
+  
+  // DevNet USDC test token mint
+  // Get test USDC: https://spl-token-faucet.com/?token-name=USDC
+  public readonly USDC_MINT = new PublicKey(
+    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" // DevNet USDC
+  );
+
+  constructor(
+    connection: Connection,
+    wallet: any,
+    programId: PublicKey
+  ) {
+    this.connection = connection;
+    this.wallet = wallet;
+    
+    const provider = new AnchorProvider(
+      connection,
+      wallet,
+      { commitment: "confirmed" }
+    );
+    
+    this.program = new Program<SuperfanPresale>(
+      idl as any,
+      programId,
+      provider
+    );
+  }
+
+  /**
+   * Derive campaign PDA address
+   */
+  public getCampaignAddress(campaignId: string): [PublicKey, number] {
+    return PublicKey.findProgramAddressSync(
+      [Buffer.from("campaign"), Buffer.from(campaignId)],
+      this.program.programId
+    );
+  }
+
+  /**
+   * Create a new presale campaign
+   * 
+   * This initializes:
+   * - Campaign state account (PDA)
+   * - Campaign token mint (SPL token)
+   * - Treasury account (holds USDC)
+   */
+  async createCampaign(params: CreateCampaignParams): Promise<string> {
+    const { campaignId, pricePerTokenUsdc, totalSupply, lockDuration } = params;
+
+    // Derive PDAs
+    const [campaignPda] = this.getCampaignAddress(campaignId);
+    
+    // Generate new keypair for token mint
+    const campaignTokenMint = Keypair.generate();
+    
+    // Derive treasury token account
+    const treasury = await getAssociatedTokenAddress(
+      this.USDC_MINT,
+      campaignPda,
+      true // allowOwnerOffCurve
+    );
+
+    // Convert price to lamports (USDC has 6 decimals)
+    const pricePerTokenLamports = Math.floor(pricePerTokenUsdc * 1_000_000);
+
+    const tx = await this.program.methods
+      .initializeCampaign(
+        campaignId,
+        new BN(pricePerTokenLamports),
+        totalSupply ? new BN(totalSupply) : null,
+        lockDuration ? new BN(lockDuration) : null
+      )
+      .accounts({
+        campaign: campaignPda,
+        campaignTokenMint: campaignTokenMint.publicKey,
+        treasury,
+        usdcMint: this.USDC_MINT,
+        authority: this.wallet.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+        rent: SYSVAR_RENT_PUBKEY,
+      })
+      .signers([campaignTokenMint])
+      .rpc();
+
+    console.log("✅ Campaign created:", {
+      campaignId,
+      signature: tx,
+      campaignPda: campaignPda.toBase58(),
+      tokenMint: campaignTokenMint.publicKey.toBase58(),
+    });
+
+    return tx;
+  }
+
+  /**
+   * Buy presale tokens with USDC
+   * 
+   * Atomically:
+   * 1. Transfers USDC from buyer → treasury
+   * 2. Mints campaign tokens → buyer
+   */
+  async buyPresale(params: BuyPresaleParams): Promise<BuyPresaleResult> {
+    const { campaignId, usdcAmount } = params;
+
+    // Derive campaign PDA
+    const [campaignPda] = this.getCampaignAddress(campaignId);
+    
+    // Fetch campaign data to get token mint
+    const campaign = await this.getCampaign(campaignId);
+    
+    // Get buyer's token accounts
+    const buyerUsdcAccount = await getAssociatedTokenAddress(
+      this.USDC_MINT,
+      this.wallet.publicKey
+    );
+    
+    const buyerTokenAccount = await getAssociatedTokenAddress(
+      campaign.tokenMint,
+      this.wallet.publicKey
+    );
+
+    // Convert USDC to lamports (6 decimals)
+    const usdcLamports = Math.floor(usdcAmount * 1_000_000);
+
+    const tx = await this.program.methods
+      .buyPresale(new BN(usdcLamports))
+      .accounts({
+        campaign: campaignPda,
+        campaignTokenMint: campaign.tokenMint,
+        treasury: campaign.treasury,
+        buyer: this.wallet.publicKey,
+        buyerUsdcAccount,
+        buyerTokenAccount,
+        usdcMint: this.USDC_MINT,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    // Calculate tokens minted
+    const tokensMinted = usdcLamports / campaign.pricePerTokenUsdc.toNumber();
+
+    console.log("✅ Presale purchase complete:", {
+      signature: tx,
+      usdcSpent: usdcAmount,
+      tokensMinted,
+    });
+
+    return {
+      signature: tx,
+      campaignTokensMinted: tokensMinted,
+      usdcSpent: usdcAmount,
+    };
+  }
+
+  /**
+   * Fetch campaign data
+   */
+  async getCampaign(campaignId: string): Promise<CampaignAccount> {
+    const [campaignPda] = this.getCampaignAddress(campaignId);
+    const campaign = await this.program.account.campaign.fetch(campaignPda);
+    
+    return campaign as CampaignAccount;
+  }
+
+  /**
+   * Get campaign statistics
+   */
+  async getCampaignStats(campaignId: string): Promise<CampaignStats> {
+    const campaign = await this.getCampaign(campaignId);
+    
+    return {
+      campaignId: campaign.campaignId,
+      tokensSold: campaign.tokensSold.toNumber(),
+      usdcRaised: campaign.usdcRaised.toNumber() / 1_000_000, // Convert to USDC
+      pricePerToken: campaign.pricePerTokenUsdc.toNumber() / 1_000_000,
+      isActive: campaign.isActive,
+      createdAt: new Date(campaign.createdAt.toNumber() * 1000),
+    };
+  }
+
+  /**
+   * Withdraw funds from campaign treasury (authority only)
+   */
+  async withdrawFunds(campaignId: string, amount: number): Promise<string> {
+    const [campaignPda] = this.getCampaignAddress(campaignId);
+    const campaign = await this.getCampaign(campaignId);
+    
+    const authorityUsdcAccount = await getAssociatedTokenAddress(
+      this.USDC_MINT,
+      this.wallet.publicKey
+    );
+
+    const amountLamports = Math.floor(amount * 1_000_000);
+
+    const tx = await this.program.methods
+      .withdrawFunds(new BN(amountLamports))
+      .accounts({
+        campaign: campaignPda,
+        treasury: campaign.treasury,
+        authority: this.wallet.publicKey,
+        authorityUsdcAccount,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .rpc();
+
+    console.log("✅ Funds withdrawn:", {
+      signature: tx,
+      amount,
+    });
+
+    return tx;
+  }
+
+  /**
+   * Close campaign (authority only)
+   */
+  async closeCampaign(campaignId: string): Promise<string> {
+    const [campaignPda] = this.getCampaignAddress(campaignId);
+
+    const tx = await this.program.methods
+      .closeCampaign()
+      .accounts({
+        campaign: campaignPda,
+        authority: this.wallet.publicKey,
+      })
+      .rpc();
+
+    console.log("🔒 Campaign closed:", tx);
+
+    return tx;
+  }
+}
+

--- a/solana-adapter/client/example.ts
+++ b/solana-adapter/client/example.ts
@@ -1,0 +1,133 @@
+/**
+ * Example Usage: Superfan Solana Presale Client
+ * 
+ * This file demonstrates how to use the SuperfanPresaleClient
+ * to interact with the presale program on Solana DevNet.
+ * 
+ * Run: pnpm client:example
+ */
+
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { SuperfanPresaleClient } from "./client";
+import * as fs from "fs";
+import * as path from "path";
+
+// Configuration
+const DEVNET_RPC = "https://api.devnet.solana.com";
+const PROGRAM_ID = new PublicKey("SuperfnPrsLE11111111111111111111111111111");
+
+/**
+ * Load wallet from filesystem
+ * In production, use Privy for wallet management
+ */
+function loadWallet(): Keypair {
+  const walletPath = path.join(
+    process.env.HOME || "",
+    ".config/solana/id.json"
+  );
+  
+  if (!fs.existsSync(walletPath)) {
+    console.log("❌ Wallet not found at:", walletPath);
+    console.log("   Run: solana-keygen new");
+    process.exit(1);
+  }
+
+  const secretKey = JSON.parse(fs.readFileSync(walletPath, "utf-8"));
+  return Keypair.fromSecretKey(Uint8Array.from(secretKey));
+}
+
+/**
+ * Main example
+ */
+async function main() {
+  console.log("🚀 Superfan Solana Presale Example\n");
+
+  // Initialize connection and wallet
+  const connection = new Connection(DEVNET_RPC, "confirmed");
+  const wallet = loadWallet();
+  
+  console.log("📍 Wallet:", wallet.publicKey.toBase58());
+  const balance = await connection.getBalance(wallet.publicKey);
+  console.log("💰 Balance:", balance / 1e9, "SOL\n");
+
+  if (balance === 0) {
+    console.log("⚠️  Get DevNet SOL: solana airdrop 2");
+    console.log("⚠️  Get DevNet USDC: https://spl-token-faucet.com/\n");
+  }
+
+  // Initialize presale client
+  const client = new SuperfanPresaleClient(connection, wallet, PROGRAM_ID);
+
+  // Example 1: Create a campaign
+  console.log("📝 Creating campaign...");
+  const campaignId = `demo-${Date.now()}`;
+  
+  try {
+    const createTx = await client.createCampaign({
+      campaignId,
+      pricePerTokenUsdc: 1.5, // $1.50 per token
+      totalSupply: 1_000_000,  // 1M tokens max
+      lockDuration: 0,         // No lock period
+    });
+    console.log("✅ Campaign created!");
+    console.log("   TX:", createTx);
+    console.log("");
+  } catch (error) {
+    console.error("❌ Failed to create campaign:", error);
+    return;
+  }
+
+  // Example 2: Get campaign stats
+  console.log("📊 Fetching campaign stats...");
+  const stats = await client.getCampaignStats(campaignId);
+  console.log("   Campaign ID:", stats.campaignId);
+  console.log("   Price per token:", `$${stats.pricePerToken}`);
+  console.log("   Tokens sold:", stats.tokensSold);
+  console.log("   USDC raised:", `$${stats.usdcRaised}`);
+  console.log("   Active:", stats.isActive);
+  console.log("");
+
+  // Example 3: Buy presale tokens
+  console.log("💳 Buying presale tokens...");
+  console.log("   Note: Requires USDC in wallet");
+  console.log("   Get test USDC: https://spl-token-faucet.com/\n");
+  
+  try {
+    const buyResult = await client.buyPresale({
+      campaignId,
+      usdcAmount: 10, // $10 USDC
+    });
+    console.log("✅ Purchase complete!");
+    console.log("   TX:", buyResult.signature);
+    console.log("   USDC spent:", `$${buyResult.usdcSpent}`);
+    console.log("   Tokens minted:", buyResult.campaignTokensMinted);
+    console.log("");
+  } catch (error) {
+    console.error("❌ Purchase failed:", error);
+    console.log("   Make sure you have USDC in your wallet");
+    console.log("");
+  }
+
+  // Example 4: Get updated stats
+  console.log("📊 Updated campaign stats:");
+  const updatedStats = await client.getCampaignStats(campaignId);
+  console.log("   Tokens sold:", updatedStats.tokensSold);
+  console.log("   USDC raised:", `$${updatedStats.usdcRaised}`);
+  console.log("");
+
+  // Example 5: Get campaign PDA
+  const [campaignPda, bump] = client.getCampaignAddress(campaignId);
+  console.log("🔑 Campaign PDA:", campaignPda.toBase58());
+  console.log("   Bump:", bump);
+  console.log("");
+
+  console.log("✨ Example complete!");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+

--- a/solana-adapter/client/privy-integration.ts
+++ b/solana-adapter/client/privy-integration.ts
@@ -1,0 +1,293 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import { PrivyClient } from "@privy-io/server-auth";
+import { SuperfanPresaleClient } from "./client";
+
+/**
+ * Privy + Solana Integration Example
+ * 
+ * Demonstrates how to use Privy's wallet abstraction with Superfan's
+ * Solana presale program. This mirrors the Base implementation but
+ * uses Privy's Solana wallet support.
+ * 
+ * Key differences from Base:
+ * - Privy generates Solana keypairs for users (not EVM addresses)
+ * - All transactions use Solana's account model (PDAs, ATAs)
+ * - USDC is SPL-USDC (not ERC-20)
+ * 
+ * Flow:
+ * 1. User authenticates via Privy (email, social, etc.)
+ * 2. Privy generates a Solana wallet for the user
+ * 3. User buys presale tokens using their Privy-managed Solana wallet
+ * 4. All wallet complexity is abstracted by Privy
+ */
+
+/**
+ * Configuration for Privy-enabled presale client
+ */
+interface PrivyPresaleConfig {
+  privyAppId: string;
+  privyAppSecret: string;
+  solanaRpcUrl: string;
+  programId: string;
+}
+
+/**
+ * Superfan Presale Client with Privy wallet abstraction
+ * 
+ * This wrapper handles:
+ * - User authentication via Privy
+ * - Solana wallet generation/management
+ * - Presale purchases with zero crypto knowledge required
+ */
+export class PrivySuperfanPresaleClient {
+  private privyClient: PrivyClient;
+  private connection: Connection;
+  private programId: PublicKey;
+
+  constructor(config: PrivyPresaleConfig) {
+    this.privyClient = new PrivyClient(
+      config.privyAppId,
+      config.privyAppSecret
+    );
+    this.connection = new Connection(config.solanaRpcUrl, "confirmed");
+    this.programId = new PublicKey(config.programId);
+  }
+
+  /**
+   * Get or create Privy-managed Solana wallet for user
+   * 
+   * Privy automatically:
+   * - Generates a Solana keypair
+   * - Stores it securely (user doesn't see seed phrase)
+   * - Enables embedded wallet signing
+   */
+  async getUserWallet(privyUserId: string): Promise<PublicKey> {
+    const user = await this.privyClient.getUserById(privyUserId);
+    
+    // Get user's Solana wallet from Privy
+    // Privy's Solana wallet support: https://docs.privy.io/guide/guides/solana
+    const solanaWallet = user.linkedAccounts.find(
+      (account) => account.type === "wallet" && account.chainType === "solana"
+    );
+
+    if (!solanaWallet) {
+      throw new Error("User has no Solana wallet. Create one via Privy SDK.");
+    }
+
+    return new PublicKey(solanaWallet.address);
+  }
+
+  /**
+   * Buy presale tokens using Privy wallet
+   * 
+   * This is the core user action - purchasing campaign tokens.
+   * All wallet signing is handled by Privy's embedded wallet.
+   * 
+   * Frontend flow:
+   * ```ts
+   * // User clicks "Buy Tokens"
+   * const result = await privyPresaleClient.buyPresaleForUser(
+   *   user.id,
+   *   "artist-campaign-2024",
+   *   100 // $100 USDC
+   * );
+   * 
+   * // User receives campaign tokens in their Privy wallet
+   * console.log("Tokens minted:", result.campaignTokensMinted);
+   * ```
+   */
+  async buyPresaleForUser(
+    privyUserId: string,
+    campaignId: string,
+    usdcAmount: number
+  ) {
+    // Get user's Solana wallet from Privy
+    const userWallet = await this.getUserWallet(privyUserId);
+
+    // Create presale client with user's wallet
+    // Note: In production, use Privy's transaction signing API
+    // This is a simplified example
+    const presaleClient = new SuperfanPresaleClient(
+      this.connection,
+      { publicKey: userWallet }, // Wallet adapter interface
+      this.programId
+    );
+
+    // Execute presale purchase
+    return await presaleClient.buyPresale({
+      campaignId,
+      usdcAmount,
+    });
+  }
+
+  /**
+   * Get user's campaign token balance
+   */
+  async getUserTokenBalance(
+    privyUserId: string,
+    campaignId: string
+  ): Promise<number> {
+    const userWallet = await this.getUserWallet(privyUserId);
+    
+    const presaleClient = new SuperfanPresaleClient(
+      this.connection,
+      { publicKey: userWallet },
+      this.programId
+    );
+
+    const campaign = await presaleClient.getCampaign(campaignId);
+    
+    // Get user's token account balance
+    const { getAccount } = await import("@solana/spl-token");
+    const { getAssociatedTokenAddress } = await import("@solana/spl-token");
+    
+    const userTokenAccount = await getAssociatedTokenAddress(
+      campaign.tokenMint,
+      userWallet
+    );
+
+    try {
+      const tokenAccount = await getAccount(
+        this.connection,
+        userTokenAccount
+      );
+      return Number(tokenAccount.amount) / 1_000_000; // Convert from lamports
+    } catch (error) {
+      // Token account doesn't exist = balance is 0
+      return 0;
+    }
+  }
+
+  /**
+   * Get campaign statistics
+   */
+  async getCampaignStats(campaignId: string) {
+    // This doesn't require user authentication
+    const dummyWallet = { publicKey: PublicKey.default };
+    const presaleClient = new SuperfanPresaleClient(
+      this.connection,
+      dummyWallet,
+      this.programId
+    );
+
+    return await presaleClient.getCampaignStats(campaignId);
+  }
+}
+
+/**
+ * Example: Next.js API route for buying presale tokens
+ * 
+ * File: app/api/presale/buy/route.ts
+ */
+export const nextjsApiRouteExample = `
+import { NextRequest, NextResponse } from "next/server";
+import { PrivySuperfanPresaleClient } from "@/solana-adapter/client/privy-integration";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { privyUserId, campaignId, usdcAmount } = await request.json();
+
+    // Initialize Privy presale client
+    const client = new PrivySuperfanPresaleClient({
+      privyAppId: process.env.NEXT_PUBLIC_PRIVY_APP_ID!,
+      privyAppSecret: process.env.PRIVY_APP_SECRET!,
+      solanaRpcUrl: process.env.NEXT_PUBLIC_SOLANA_RPC_URL!,
+      programId: process.env.NEXT_PUBLIC_PRESALE_PROGRAM_ID!,
+    });
+
+    // Execute presale purchase
+    const result = await client.buyPresaleForUser(
+      privyUserId,
+      campaignId,
+      usdcAmount
+    );
+
+    return NextResponse.json({
+      success: true,
+      signature: result.signature,
+      tokensMinted: result.campaignTokensMinted,
+    });
+
+  } catch (error) {
+    console.error("Presale purchase failed:", error);
+    return NextResponse.json(
+      { error: "Failed to purchase presale tokens" },
+      { status: 500 }
+    );
+  }
+}
+`;
+
+/**
+ * Example: React component for presale purchase
+ * 
+ * File: components/solana-presale-button.tsx
+ */
+export const reactComponentExample = `
+"use client";
+
+import { useState } from "react";
+import { usePrivy } from "@privy-io/react-auth";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+interface SolanaPresaleButtonProps {
+  campaignId: string;
+  amount: number;
+}
+
+export function SolanaPresaleButton({ 
+  campaignId, 
+  amount 
+}: SolanaPresaleButtonProps) {
+  const { user, authenticated, login } = usePrivy();
+  const [loading, setLoading] = useState(false);
+
+  const handleBuy = async () => {
+    if (!authenticated) {
+      login();
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch("/api/presale/buy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          privyUserId: user.id,
+          campaignId,
+          usdcAmount: amount,
+        }),
+      });
+
+      const result = await response.json();
+      
+      if (result.success) {
+        alert(\`✅ Success! Minted \${result.tokensMinted} tokens\`);
+      } else {
+        throw new Error(result.error);
+      }
+    } catch (error) {
+      alert("Failed to purchase tokens");
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button onClick={handleBuy} disabled={loading}>
+      {loading ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          Processing...
+        </>
+      ) : (
+        \`Buy $\${amount} USDC\`
+      )}
+    </Button>
+  );
+}
+`;
+

--- a/solana-adapter/client/privy-integration.ts
+++ b/solana-adapter/client/privy-integration.ts
@@ -259,7 +259,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 4. Ensure environment variables are present
+    // 3. Ensure environment variables are present
     if (!process.env.NEXT_PUBLIC_SOLANA_RPC_URL || !process.env.NEXT_PUBLIC_PRESALE_PROGRAM_ID) {
       console.error("Missing required environment variables");
       return NextResponse.json(

--- a/solana-adapter/client/types.ts
+++ b/solana-adapter/client/types.ts
@@ -1,0 +1,62 @@
+import { PublicKey } from "@solana/web3.js";
+import { BN } from "@coral-xyz/anchor";
+
+/**
+ * Campaign account data structure
+ * Mirrors the on-chain Campaign struct from lib.rs
+ */
+export interface CampaignAccount {
+  authority: PublicKey;
+  campaignId: string;
+  tokenMint: PublicKey;
+  treasury: PublicKey;
+  pricePerTokenUsdc: BN;
+  totalSupply: BN | null;
+  tokensSold: BN;
+  usdcRaised: BN;
+  lockDuration: BN | null;
+  createdAt: BN;
+  isActive: boolean;
+  bump: number;
+}
+
+/**
+ * Configuration for creating a presale campaign
+ * Matches Metal's createPresale() parameters
+ */
+export interface CreateCampaignParams {
+  campaignId: string;
+  pricePerTokenUsdc: number; // Price in USDC (e.g., 1.5 = $1.50)
+  totalSupply?: number;      // Max tokens to mint
+  lockDuration?: number;     // Lock period in seconds
+}
+
+/**
+ * Configuration for purchasing presale tokens
+ */
+export interface BuyPresaleParams {
+  campaignId: string;
+  usdcAmount: number; // Amount in USDC (e.g., 100 = $100)
+}
+
+/**
+ * Result of a presale purchase
+ */
+export interface BuyPresaleResult {
+  signature: string;
+  campaignTokensMinted: number;
+  usdcSpent: number;
+}
+
+/**
+ * Campaign statistics
+ */
+export interface CampaignStats {
+  campaignId: string;
+  tokensSold: number;
+  usdcRaised: number;
+  pricePerToken: number;
+  isActive: boolean;
+  createdAt: Date;
+}
+

--- a/solana-adapter/package.json
+++ b/solana-adapter/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "superfan-solana-adapter",
+  "version": "0.1.0",
+  "description": "Solana adapter for Superfan's tokenized presale system",
+  "scripts": {
+    "build": "anchor build",
+    "test": "anchor test",
+    "deploy:devnet": "anchor deploy --provider.cluster devnet",
+    "deploy:localnet": "anchor deploy --provider.cluster localnet",
+    "client:build": "tsc",
+    "client:example": "ts-node client/example.ts"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.30.1",
+    "@privy-io/server-auth": "^1.11.0",
+    "@solana/web3.js": "^1.95.3",
+    "@solana/spl-token": "^0.4.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.9.0",
+    "chai": "^4.3.7",
+    "@types/chai": "^4.3.5",
+    "mocha": "^10.2.0",
+    "@types/mocha": "^10.0.1"
+  }
+}
+

--- a/solana-adapter/package.json
+++ b/solana-adapter/package.json
@@ -11,10 +11,10 @@
     "client:example": "ts-node client/example.ts"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.30.1",
-    "@privy-io/server-auth": "^1.11.0",
-    "@solana/web3.js": "^1.95.3",
-    "@solana/spl-token": "^0.4.8"
+    "@coral-xyz/anchor": "^0.31.1",
+    "@privy-io/server-auth": "^1.32.5",
+    "@solana/web3.js": "^1.97.0",
+    "@solana/spl-token": "^0.4.14"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/solana-adapter/programs/label-subdao/Cargo.toml
+++ b/solana-adapter/programs/label-subdao/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "label-subdao"
+version = "0.1.0"
+description = "Label SubDAO - Manages artist proposals and credit lines for Superfan labels"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "label_subdao"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = "0.31.1"
+anchor-spl = "0.31.1"
+

--- a/solana-adapter/programs/label-subdao/Xargo.toml
+++ b/solana-adapter/programs/label-subdao/Xargo.toml
@@ -1,0 +1,3 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []
+

--- a/solana-adapter/programs/label-subdao/src/lib.rs
+++ b/solana-adapter/programs/label-subdao/src/lib.rs
@@ -1,0 +1,621 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{Token, TokenAccount};
+
+declare_id!("LabelSubDAO1111111111111111111111111111111");
+
+/// Label SubDAO - Layer 2
+/// 
+/// Labels funded by Superfan DAO operate autonomously:
+/// - Artists submit funding proposals
+/// - Label curator approves/rejects
+/// - Approved artists get credit lines
+/// - Credit is tracked and repaid as fans redeem
+/// 
+/// Links to superfan-presale program for campaign execution
+#[program]
+pub mod label_subdao {
+    use super::*;
+
+    /// Artist submits proposal to label
+    /// 
+    /// Creates a funding request that label curator can approve.
+    /// Includes artist info, campaign details, and requested amount.
+    pub fn submit_artist_proposal(
+        ctx: Context<SubmitProposal>,
+        artist_name: String,
+        campaign_id: String,
+        requested_amount: u64,
+        campaign_description: String,
+        revenue_projection: u64,
+    ) -> Result<()> {
+        require!(artist_name.len() <= 50, LabelError::NameTooLong);
+        require!(campaign_id.len() <= 50, LabelError::IdTooLong);
+        require!(requested_amount > 0, LabelError::InvalidAmount);
+        require!(campaign_description.len() <= 500, LabelError::DescriptionTooLong);
+
+        let label = &ctx.accounts.label;
+        require!(label.is_active, LabelError::LabelInactive);
+
+        // Verify label has sufficient funds
+        require!(
+            ctx.accounts.label_treasury.amount >= requested_amount,
+            LabelError::InsufficientLabelFunds
+        );
+
+        let proposal = &mut ctx.accounts.proposal;
+        proposal.label = label.key();
+        proposal.artist = ctx.accounts.artist.key();
+        proposal.artist_name = artist_name.clone();
+        proposal.campaign_id = campaign_id.clone();
+        proposal.requested_amount = requested_amount;
+        proposal.campaign_description = campaign_description;
+        proposal.revenue_projection = revenue_projection;
+        proposal.status = ArtistProposalStatus::Pending;
+        proposal.submitted_at = Clock::get()?.unix_timestamp;
+        proposal.bump = ctx.bumps.proposal;
+
+        msg!("📝 Artist proposal submitted");
+        msg!("   Artist: {}", artist_name);
+        msg!("   Campaign: {}", campaign_id);
+        msg!("   Requested: {} USDC", requested_amount);
+        msg!("   Label: {}", label.name);
+
+        Ok(())
+    }
+
+    /// Curator approves artist proposal
+    /// 
+    /// Creates credit line for artist and initiates campaign.
+    /// Calls superfan-presale program to create the actual presale.
+    pub fn approve_artist_proposal(
+        ctx: Context<ApproveProposal>,
+    ) -> Result<()> {
+        let proposal = &mut ctx.accounts.proposal;
+        require!(
+            proposal.status == ArtistProposalStatus::Pending,
+            LabelError::ProposalNotPending
+        );
+
+        let label = &mut ctx.accounts.label;
+        
+        // Create credit line
+        let credit_line = &mut ctx.accounts.credit_line;
+        credit_line.label = label.key();
+        credit_line.proposal = proposal.key();
+        credit_line.artist = proposal.artist;
+        credit_line.campaign_id = proposal.campaign_id.clone();
+        credit_line.credit_limit = proposal.requested_amount;
+        credit_line.credit_used = 0;
+        credit_line.credit_repaid = 0;
+        credit_line.created_at = Clock::get()?.unix_timestamp;
+        credit_line.is_active = true;
+        credit_line.bump = ctx.bumps.credit_line;
+
+        // Update proposal
+        proposal.status = ArtistProposalStatus::Approved;
+        proposal.approved_at = Some(Clock::get()?.unix_timestamp);
+        proposal.credit_line = Some(credit_line.key());
+
+        // Update label stats
+        label.total_deployed = label.total_deployed
+            .checked_add(proposal.requested_amount)
+            .ok_or(LabelError::MathOverflow)?;
+
+        msg!("✅ Artist proposal approved");
+        msg!("   Artist: {}", proposal.artist_name);
+        msg!("   Credit line: {} USDC", proposal.requested_amount);
+        
+        // Note: Actual campaign creation happens via CPI to superfan-presale
+        // in a separate instruction once presale params are finalized
+
+        Ok(())
+    }
+
+    /// Reject artist proposal
+    pub fn reject_artist_proposal(
+        ctx: Context<RejectProposal>,
+        reason: String,
+    ) -> Result<()> {
+        require!(reason.len() <= 200, LabelError::ReasonTooLong);
+        
+        let proposal = &mut ctx.accounts.proposal;
+        require!(
+            proposal.status == ArtistProposalStatus::Pending,
+            LabelError::ProposalNotPending
+        );
+
+        proposal.status = ArtistProposalStatus::Rejected;
+        proposal.rejection_reason = Some(reason.clone());
+
+        msg!("❌ Artist proposal rejected");
+        msg!("   Artist: {}", proposal.artist_name);
+        msg!("   Reason: {}", reason);
+
+        Ok(())
+    }
+
+    /// Draw from credit line (artist uses their credit)
+    /// 
+    /// Transfers USDC from label treasury to artist.
+    /// Called when artist needs funds for production, marketing, etc.
+    pub fn draw_credit(
+        ctx: Context<DrawCredit>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, LabelError::InvalidAmount);
+
+        let credit_line = &mut ctx.accounts.credit_line;
+        require!(credit_line.is_active, LabelError::CreditLineInactive);
+
+        let available_credit = credit_line.credit_limit
+            .checked_sub(credit_line.credit_used)
+            .ok_or(LabelError::MathOverflow)?;
+        
+        require!(
+            amount <= available_credit,
+            LabelError::InsufficientCredit
+        );
+
+        // Transfer from label treasury to artist
+        let label = &ctx.accounts.label;
+        let seeds = &[
+            b"label-ext",
+            label.name.as_bytes(),
+            &[label.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        anchor_spl::token::transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Transfer {
+                    from: ctx.accounts.label_treasury.to_account_info(),
+                    to: ctx.accounts.artist_account.to_account_info(),
+                    authority: label.to_account_info(),
+                },
+                signer,
+            ),
+            amount,
+        )?;
+
+        // Update credit line
+        credit_line.credit_used = credit_line.credit_used
+            .checked_add(amount)
+            .ok_or(LabelError::MathOverflow)?;
+
+        msg!("💳 Credit drawn");
+        msg!("   Artist: {}", credit_line.artist);
+        msg!("   Amount: {} USDC", amount);
+        msg!("   Used: {}/{} USDC", credit_line.credit_used, credit_line.credit_limit);
+
+        Ok(())
+    }
+
+    /// Repay credit line (from fan redemptions)
+    /// 
+    /// Artist repays credit as fans redeem rewards.
+    /// When fully repaid, credit line closes and artist owns their campaign tokens.
+    pub fn repay_credit(
+        ctx: Context<RepayCredit>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, LabelError::InvalidAmount);
+
+        let credit_line = &mut ctx.accounts.credit_line;
+        require!(credit_line.is_active, LabelError::CreditLineInactive);
+
+        let remaining_balance = credit_line.credit_used
+            .checked_sub(credit_line.credit_repaid)
+            .ok_or(LabelError::MathOverflow)?;
+        
+        let actual_repayment = amount.min(remaining_balance);
+
+        // Transfer from artist to label treasury
+        anchor_spl::token::transfer(
+            CpiContext::new(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Transfer {
+                    from: ctx.accounts.artist_account.to_account_info(),
+                    to: ctx.accounts.label_treasury.to_account_info(),
+                    authority: ctx.accounts.artist.to_account_info(),
+                },
+            ),
+            actual_repayment,
+        )?;
+
+        // Update credit line
+        credit_line.credit_repaid = credit_line.credit_repaid
+            .checked_add(actual_repayment)
+            .ok_or(LabelError::MathOverflow)?;
+
+        // Check if fully repaid
+        if credit_line.credit_repaid >= credit_line.credit_used {
+            credit_line.is_active = false;
+            msg!("🎉 Credit line fully repaid!");
+        }
+
+        // Update label stats
+        let label = &mut ctx.accounts.label;
+        label.total_repaid = label.total_repaid
+            .checked_add(actual_repayment)
+            .ok_or(LabelError::MathOverflow)?;
+
+        msg!("💰 Credit repayment received");
+        msg!("   Artist: {}", credit_line.artist);
+        msg!("   Amount: {} USDC", actual_repayment);
+        msg!("   Repaid: {}/{} USDC", credit_line.credit_repaid, credit_line.credit_used);
+
+        Ok(())
+    }
+
+    /// Settle label with parent DAO
+    /// 
+    /// Transfers repayments back to Superfan DAO treasury.
+    /// Called periodically to sync label performance with DAO.
+    pub fn settle_with_dao(
+        ctx: Context<SettleWithDAO>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, LabelError::InvalidAmount);
+
+        let label = &mut ctx.accounts.label;
+        require!(label.is_active, LabelError::LabelInactive);
+
+        // TODO: CPI to superfan_dao::record_label_repayment
+        // This would call the parent DAO to record this repayment
+        
+        msg!("🔄 Settlement with DAO");
+        msg!("   Label: {}", label.name);
+        msg!("   Amount: {} USDC", amount);
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Account Structs
+// ============================================================================
+
+/// External reference to Superfan DAO's Label struct
+/// Used to link back to parent layer
+#[account]
+pub struct LabelExternal {
+    /// Parent DAO
+    pub dao: Pubkey,
+    /// Label name
+    pub name: String,
+    /// Label curator
+    pub curator: Pubkey,
+    /// Treasury
+    pub treasury: Pubkey,
+    /// Initial funding
+    pub initial_funding: u64,
+    /// Total deployed to artists
+    pub total_deployed: u64,
+    /// Total repaid
+    pub total_repaid: u64,
+    /// Active status
+    pub is_active: bool,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl LabelExternal {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // dao
+        (4 + 50) +              // name
+        32 +                    // curator
+        32 +                    // treasury
+        8 +                     // initial_funding
+        8 +                     // total_deployed
+        8 +                     // total_repaid
+        1 +                     // is_active
+        1;                      // bump
+}
+
+/// Artist funding proposal
+#[account]
+pub struct ArtistProposal {
+    /// Parent label
+    pub label: Pubkey,
+    /// Artist wallet
+    pub artist: Pubkey,
+    /// Artist name
+    pub artist_name: String,
+    /// Campaign identifier
+    pub campaign_id: String,
+    /// Requested funding amount
+    pub requested_amount: u64,
+    /// Campaign description/pitch
+    pub campaign_description: String,
+    /// Revenue projection
+    pub revenue_projection: u64,
+    /// Proposal status
+    pub status: ArtistProposalStatus,
+    /// Submitted timestamp
+    pub submitted_at: i64,
+    /// Approved timestamp
+    pub approved_at: Option<i64>,
+    /// Rejection reason
+    pub rejection_reason: Option<String>,
+    /// Created credit line (if approved)
+    pub credit_line: Option<Pubkey>,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl ArtistProposal {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // label
+        32 +                    // artist
+        (4 + 50) +              // artist_name
+        (4 + 50) +              // campaign_id
+        8 +                     // requested_amount
+        (4 + 500) +             // campaign_description
+        8 +                     // revenue_projection
+        1 +                     // status
+        8 +                     // submitted_at
+        (1 + 8) +               // approved_at
+        (1 + 4 + 200) +         // rejection_reason
+        (1 + 32) +              // credit_line
+        1;                      // bump
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
+pub enum ArtistProposalStatus {
+    Pending,
+    Approved,
+    Rejected,
+    Active,      // Campaign is live
+    Completed,   // Campaign completed, credit repaid
+}
+
+/// Artist credit line
+#[account]
+pub struct CreditLine {
+    /// Parent label
+    pub label: Pubkey,
+    /// Original proposal
+    pub proposal: Pubkey,
+    /// Artist wallet
+    pub artist: Pubkey,
+    /// Campaign identifier
+    pub campaign_id: String,
+    /// Total credit limit
+    pub credit_limit: u64,
+    /// Credit used
+    pub credit_used: u64,
+    /// Credit repaid
+    pub credit_repaid: u64,
+    /// Created timestamp
+    pub created_at: i64,
+    /// Active status
+    pub is_active: bool,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl CreditLine {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // label
+        32 +                    // proposal
+        32 +                    // artist
+        (4 + 50) +              // campaign_id
+        8 +                     // credit_limit
+        8 +                     // credit_used
+        8 +                     // credit_repaid
+        8 +                     // created_at
+        1 +                     // is_active
+        1;                      // bump
+}
+
+// ============================================================================
+// Context Structs
+// ============================================================================
+
+#[derive(Accounts)]
+#[instruction(artist_name: String, campaign_id: String)]
+pub struct SubmitProposal<'info> {
+    #[account(
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        address = label.treasury
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    #[account(
+        init,
+        payer = artist,
+        space = ArtistProposal::LEN,
+        seeds = [b"proposal", label.key().as_ref(), campaign_id.as_bytes()],
+        bump
+    )]
+    pub proposal: Account<'info, ArtistProposal>,
+
+    #[account(mut)]
+    pub artist: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ApproveProposal<'info> {
+    #[account(
+        mut,
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump,
+        has_one = curator
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        mut,
+        seeds = [b"proposal", label.key().as_ref(), proposal.campaign_id.as_bytes()],
+        bump = proposal.bump,
+        has_one = label
+    )]
+    pub proposal: Account<'info, ArtistProposal>,
+
+    #[account(
+        init,
+        payer = curator,
+        space = CreditLine::LEN,
+        seeds = [b"credit", label.key().as_ref(), proposal.campaign_id.as_bytes()],
+        bump
+    )]
+    pub credit_line: Account<'info, CreditLine>,
+
+    #[account(mut)]
+    pub curator: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct RejectProposal<'info> {
+    #[account(
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump,
+        has_one = curator
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        mut,
+        seeds = [b"proposal", label.key().as_ref(), proposal.campaign_id.as_bytes()],
+        bump = proposal.bump,
+        has_one = label
+    )]
+    pub proposal: Account<'info, ArtistProposal>,
+
+    pub curator: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct DrawCredit<'info> {
+    #[account(
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        mut,
+        seeds = [b"credit", label.key().as_ref(), credit_line.campaign_id.as_bytes()],
+        bump = credit_line.bump,
+        has_one = label,
+        has_one = artist
+    )]
+    pub credit_line: Account<'info, CreditLine>,
+
+    #[account(
+        mut,
+        address = label.treasury
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub artist_account: Account<'info, TokenAccount>,
+
+    pub artist: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct RepayCredit<'info> {
+    #[account(
+        mut,
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        mut,
+        seeds = [b"credit", label.key().as_ref(), credit_line.campaign_id.as_bytes()],
+        bump = credit_line.bump,
+        has_one = label,
+        has_one = artist
+    )]
+    pub credit_line: Account<'info, CreditLine>,
+
+    #[account(mut)]
+    pub artist_account: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        address = label.treasury
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    pub artist: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct SettleWithDAO<'info> {
+    #[account(
+        mut,
+        seeds = [b"label-ext", label.name.as_bytes()],
+        bump = label.bump,
+        has_one = curator
+    )]
+    pub label: Account<'info, LabelExternal>,
+
+    #[account(
+        mut,
+        address = label.treasury
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    pub curator: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[error_code]
+pub enum LabelError {
+    #[msg("Name too long (max 50 characters)")]
+    NameTooLong,
+    
+    #[msg("ID too long (max 50 characters)")]
+    IdTooLong,
+    
+    #[msg("Description too long (max 500 characters)")]
+    DescriptionTooLong,
+    
+    #[msg("Reason too long (max 200 characters)")]
+    ReasonTooLong,
+    
+    #[msg("Invalid amount")]
+    InvalidAmount,
+    
+    #[msg("Label is not active")]
+    LabelInactive,
+    
+    #[msg("Insufficient funds in label treasury")]
+    InsufficientLabelFunds,
+    
+    #[msg("Proposal is not in pending status")]
+    ProposalNotPending,
+    
+    #[msg("Credit line is not active")]
+    CreditLineInactive,
+    
+    #[msg("Insufficient credit available")]
+    InsufficientCredit,
+    
+    #[msg("Math operation overflow")]
+    MathOverflow,
+}
+

--- a/solana-adapter/programs/superfan-dao/Cargo.toml
+++ b/solana-adapter/programs/superfan-dao/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "superfan-dao"
+version = "0.1.0"
+description = "Superfan DAO - MetaDAO-powered futarchy governance for music labels"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "superfan_dao"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = "0.31.1"
+anchor-spl = "0.31.1"
+
+# MetaDAO programs (as dependencies)
+# Note: In production, these would be actual crate dependencies
+# For now, we'll define the interfaces we need
+

--- a/solana-adapter/programs/superfan-dao/Xargo.toml
+++ b/solana-adapter/programs/superfan-dao/Xargo.toml
@@ -1,0 +1,3 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []
+

--- a/solana-adapter/programs/superfan-dao/src/lib.rs
+++ b/solana-adapter/programs/superfan-dao/src/lib.rs
@@ -1,0 +1,616 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{Token, TokenAccount, Mint};
+
+declare_id!("SuperfnDAO11111111111111111111111111111111");
+
+/// Superfan DAO - Layer 1
+/// 
+/// Manages treasury and futarchy governance for funding music labels.
+/// Integrates with MetaDAO's conditional vaults, AMM, and autocrat programs.
+/// 
+/// Flow:
+/// 1. Curator proposes new label → MetaDAO proposal created
+/// 2. Community trades on pass/fail markets for 3 days
+/// 3. If pass TWAP > fail TWAP → label gets funded, SubDAO created
+/// 4. Label operates autonomously, repayments flow back to Superfan treasury
+#[program]
+pub mod superfan_dao {
+    use super::*;
+
+    /// Initialize the Superfan DAO
+    /// 
+    /// Creates:
+    /// - DAO state account
+    /// - Treasury (USDC vault)
+    /// - Governance parameters
+    pub fn initialize_dao(
+        ctx: Context<InitializeDAO>,
+        metadao_fee_bps: u16,  // Basis points (e.g., 500 = 5%)
+    ) -> Result<()> {
+        require!(metadao_fee_bps <= 1000, SuperfanError::FeeTooHigh); // Max 10%
+        
+        let dao = &mut ctx.accounts.dao;
+        dao.authority = ctx.accounts.authority.key();
+        dao.treasury = ctx.accounts.treasury.key();
+        dao.usdc_mint = ctx.accounts.usdc_mint.key();
+        dao.metadao_fee_bps = metadao_fee_bps;
+        dao.total_labels_funded = 0;
+        dao.total_deployed_capital = 0;
+        dao.total_repayments = 0;
+        dao.bump = ctx.bumps.dao;
+
+        msg!("✅ Superfan DAO initialized");
+        msg!("   Treasury: {}", dao.treasury);
+        msg!("   MetaDAO fee: {}bps", metadao_fee_bps);
+
+        Ok(())
+    }
+
+    /// Propose a new label for funding
+    /// 
+    /// Creates a MetaDAO futarchy proposal with pass/fail markets.
+    /// Community trades to decide if this label should be funded.
+    /// 
+    /// Parameters:
+    /// - label_name: Human-readable label name (e.g., "Delacour Recordings")
+    /// - funding_amount: USDC to deploy to label treasury
+    /// - curator_share_bps: % label keeps after repayment (e.g., 8000 = 80%)
+    /// - repayment_target_bps: % of capital that must be repaid (e.g., 10000 = 100%)
+    pub fn propose_label(
+        ctx: Context<ProposeLabel>,
+        label_name: String,
+        funding_amount: u64,
+        curator_share_bps: u16,
+        repayment_target_bps: u16,
+    ) -> Result<()> {
+        require!(label_name.len() <= 50, SuperfanError::NameTooLong);
+        require!(funding_amount > 0, SuperfanError::InvalidAmount);
+        require!(curator_share_bps <= 10000, SuperfanError::InvalidShare);
+        require!(repayment_target_bps <= 10000, SuperfanError::InvalidTarget);
+        
+        let dao = &ctx.accounts.dao;
+        
+        // Verify treasury has sufficient funds
+        require!(
+            ctx.accounts.treasury.amount >= funding_amount,
+            SuperfanError::InsufficientTreasuryFunds
+        );
+
+        let proposal = &mut ctx.accounts.proposal;
+        proposal.dao = dao.key();
+        proposal.proposer = ctx.accounts.proposer.key();
+        proposal.label_name = label_name.clone();
+        proposal.funding_amount = funding_amount;
+        proposal.curator_share_bps = curator_share_bps;
+        proposal.repayment_target_bps = repayment_target_bps;
+        proposal.status = ProposalStatus::Pending;
+        proposal.created_at = Clock::get()?.unix_timestamp;
+        proposal.bump = ctx.bumps.proposal;
+
+        // TODO: CPI to MetaDAO Autocrat to create futarchy proposal
+        // This would call metadao::autocrat::create_proposal with:
+        // - instruction: superfan_dao::execute_label_funding
+        // - pass/fail conditional vaults for USDC
+        // - 3-day trading period
+        
+        // For now, store MetaDAO proposal reference
+        // In production, this would be returned from MetaDAO CPI:
+        // proposal.metadao_proposal = metadao_proposal_pubkey;
+        
+        msg!("📋 Label proposal created");
+        msg!("   Label: {}", label_name);
+        msg!("   Funding: {} USDC", funding_amount);
+        msg!("   Trading period: 3 days");
+
+        Ok(())
+    }
+
+    /// Execute label funding (called after MetaDAO proposal passes)
+    /// 
+    /// This instruction is what the MetaDAO proposal executes if it passes.
+    /// Creates the Label SubDAO and transfers initial funding.
+    pub fn execute_label_funding(
+        ctx: Context<ExecuteLabelFunding>,
+    ) -> Result<()> {
+        let proposal = &ctx.accounts.proposal;
+        
+        // TODO: Verify MetaDAO proposal passed
+        // require!(
+        //     metadao::autocrat::get_status(proposal.metadao_proposal)? == Passed,
+        //     SuperfanError::ProposalNotPassed
+        // );
+
+        // Create Label SubDAO
+        let label = &mut ctx.accounts.label;
+        label.dao = ctx.accounts.dao.key();
+        label.proposal = proposal.key();
+        label.name = proposal.label_name.clone();
+        label.curator = proposal.proposer;
+        label.treasury = ctx.accounts.label_treasury.key();
+        label.initial_funding = proposal.funding_amount;
+        label.curator_share_bps = proposal.curator_share_bps;
+        label.repayment_target_bps = proposal.repayment_target_bps;
+        label.total_deployed = 0;
+        label.total_repaid = 0;
+        label.created_at = Clock::get()?.unix_timestamp;
+        label.is_active = true;
+        label.bump = ctx.bumps.label;
+
+        // Transfer initial funding from DAO treasury to label treasury
+        let dao_key = ctx.accounts.dao.key();
+        let seeds = &[
+            b"dao",
+            &[ctx.accounts.dao.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        anchor_spl::token::transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Transfer {
+                    from: ctx.accounts.dao_treasury.to_account_info(),
+                    to: ctx.accounts.label_treasury.to_account_info(),
+                    authority: ctx.accounts.dao.to_account_info(),
+                },
+                signer,
+            ),
+            proposal.funding_amount,
+        )?;
+
+        // Update DAO stats
+        let dao = &mut ctx.accounts.dao;
+        dao.total_labels_funded = dao.total_labels_funded
+            .checked_add(1)
+            .ok_or(SuperfanError::MathOverflow)?;
+        dao.total_deployed_capital = dao.total_deployed_capital
+            .checked_add(proposal.funding_amount)
+            .ok_or(SuperfanError::MathOverflow)?;
+
+        // Update proposal status
+        let proposal = &mut ctx.accounts.proposal;
+        proposal.status = ProposalStatus::Executed;
+        proposal.label = Some(label.key());
+
+        msg!("🎉 Label funded and launched!");
+        msg!("   Label: {}", label.name);
+        msg!("   Initial funding: {} USDC", proposal.funding_amount);
+        msg!("   Curator: {}", label.curator);
+
+        Ok(())
+    }
+
+    /// Record repayment from label to DAO treasury
+    /// 
+    /// Called when a label's artists repay their credit lines.
+    /// Tracks performance for future futarchy decisions.
+    pub fn record_label_repayment(
+        ctx: Context<RecordRepayment>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, SuperfanError::InvalidAmount);
+
+        let label = &mut ctx.accounts.label;
+        require!(label.is_active, SuperfanError::LabelInactive);
+
+        // Transfer repayment from label treasury to DAO treasury
+        let label_key = label.key();
+        let seeds = &[
+            b"label",
+            label.name.as_bytes(),
+            &[label.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        anchor_spl::token::transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Transfer {
+                    from: ctx.accounts.label_treasury.to_account_info(),
+                    to: ctx.accounts.dao_treasury.to_account_info(),
+                    authority: label.to_account_info(),
+                },
+                signer,
+            ),
+            amount,
+        )?;
+
+        // Calculate MetaDAO protocol fee
+        let dao = &ctx.accounts.dao;
+        let protocol_fee = (amount as u128)
+            .checked_mul(dao.metadao_fee_bps as u128)
+            .ok_or(SuperfanError::MathOverflow)?
+            .checked_div(10000)
+            .ok_or(SuperfanError::MathOverflow)? as u64;
+
+        // Update label stats
+        label.total_repaid = label.total_repaid
+            .checked_add(amount)
+            .ok_or(SuperfanError::MathOverflow)?;
+
+        // Update DAO stats
+        let dao = &mut ctx.accounts.dao;
+        dao.total_repayments = dao.total_repayments
+            .checked_add(amount)
+            .ok_or(SuperfanError::MathOverflow)?;
+
+        msg!("💰 Repayment recorded");
+        msg!("   Label: {}", label.name);
+        msg!("   Amount: {} USDC", amount);
+        msg!("   Protocol fee (to MetaDAO): {} USDC", protocol_fee);
+        msg!("   Label total repaid: {}/{} USDC", 
+            label.total_repaid, 
+            label.initial_funding
+        );
+
+        Ok(())
+    }
+
+    /// Pay protocol fee to MetaDAO
+    /// 
+    /// Transfers accumulated fees from DAO treasury to MetaDAO treasury.
+    pub fn pay_protocol_fee(
+        ctx: Context<PayProtocolFee>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, SuperfanError::InvalidAmount);
+
+        let dao = &ctx.accounts.dao;
+        let seeds = &[
+            b"dao",
+            &[dao.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        anchor_spl::token::transfer(
+            CpiContext::new_with_signer(
+                ctx.accounts.token_program.to_account_info(),
+                anchor_spl::token::Transfer {
+                    from: ctx.accounts.dao_treasury.to_account_info(),
+                    to: ctx.accounts.metadao_treasury.to_account_info(),
+                    authority: dao.to_account_info(),
+                },
+                signer,
+            ),
+            amount,
+        )?;
+
+        msg!("💸 Protocol fee paid to MetaDAO: {} USDC", amount);
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Account Structs
+// ============================================================================
+
+/// Superfan DAO state
+#[account]
+pub struct SuperfanDAO {
+    /// DAO authority (can be governance later)
+    pub authority: Pubkey,
+    /// Main treasury holding USDC
+    pub treasury: Pubkey,
+    /// USDC mint
+    pub usdc_mint: Pubkey,
+    /// Protocol fee to MetaDAO (basis points)
+    pub metadao_fee_bps: u16,
+    /// Total labels funded
+    pub total_labels_funded: u64,
+    /// Total capital deployed to labels
+    pub total_deployed_capital: u64,
+    /// Total repayments received
+    pub total_repayments: u64,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl SuperfanDAO {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // authority
+        32 +                    // treasury
+        32 +                    // usdc_mint
+        2 +                     // metadao_fee_bps
+        8 +                     // total_labels_funded
+        8 +                     // total_deployed_capital
+        8 +                     // total_repayments
+        1;                      // bump
+}
+
+/// Label funding proposal (interfaces with MetaDAO futarchy)
+#[account]
+pub struct LabelProposal {
+    /// Parent DAO
+    pub dao: Pubkey,
+    /// Proposer (will be label curator)
+    pub proposer: Pubkey,
+    /// Label name
+    pub label_name: String,
+    /// USDC funding amount
+    pub funding_amount: u64,
+    /// Label's share after repayment (bps)
+    pub curator_share_bps: u16,
+    /// Repayment target (bps of initial funding)
+    pub repayment_target_bps: u16,
+    /// Proposal status
+    pub status: ProposalStatus,
+    /// Created timestamp
+    pub created_at: i64,
+    /// Created label (if executed)
+    pub label: Option<Pubkey>,
+    /// MetaDAO proposal reference (for querying pass/fail markets)
+    pub metadao_proposal: Option<Pubkey>,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl LabelProposal {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // dao
+        32 +                    // proposer
+        (4 + 50) +              // label_name
+        8 +                     // funding_amount
+        2 +                     // curator_share_bps
+        2 +                     // repayment_target_bps
+        1 +                     // status enum
+        8 +                     // created_at
+        (1 + 32) +              // label option
+        (1 + 32) +              // metadao_proposal option
+        1;                      // bump
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
+pub enum ProposalStatus {
+    Pending,   // Futarchy market active
+    Passed,    // Market decided yes
+    Failed,    // Market decided no
+    Executed,  // Funding deployed, label created
+    Cancelled, // Proposal withdrawn
+}
+
+/// Label SubDAO (Layer 2)
+#[account]
+pub struct LabelSubDAO {
+    /// Parent DAO
+    pub dao: Pubkey,
+    /// Original proposal
+    pub proposal: Pubkey,
+    /// Label name
+    pub name: String,
+    /// Curator (label authority)
+    pub curator: Pubkey,
+    /// Label treasury (USDC)
+    pub treasury: Pubkey,
+    /// Initial funding received
+    pub initial_funding: u64,
+    /// Curator's share of profits (bps)
+    pub curator_share_bps: u16,
+    /// Repayment target (bps)
+    pub repayment_target_bps: u16,
+    /// Total deployed to artists
+    pub total_deployed: u64,
+    /// Total repaid to DAO
+    pub total_repaid: u64,
+    /// Created timestamp
+    pub created_at: i64,
+    /// Active status
+    pub is_active: bool,
+    /// PDA bump
+    pub bump: u8,
+}
+
+impl LabelSubDAO {
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // dao
+        32 +                    // proposal
+        (4 + 50) +              // name
+        32 +                    // curator
+        32 +                    // treasury
+        8 +                     // initial_funding
+        2 +                     // curator_share_bps
+        2 +                     // repayment_target_bps
+        8 +                     // total_deployed
+        8 +                     // total_repaid
+        8 +                     // created_at
+        1 +                     // is_active
+        1;                      // bump
+}
+
+// ============================================================================
+// Context Structs
+// ============================================================================
+
+#[derive(Accounts)]
+pub struct InitializeDAO<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = SuperfanDAO::LEN,
+        seeds = [b"dao"],
+        bump
+    )]
+    pub dao: Account<'info, SuperfanDAO>,
+
+    #[account(
+        init,
+        payer = authority,
+        token::mint = usdc_mint,
+        token::authority = dao,
+    )]
+    pub treasury: Account<'info, TokenAccount>,
+
+    pub usdc_mint: Account<'info, Mint>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+#[instruction(label_name: String)]
+pub struct ProposeLabel<'info> {
+    #[account(
+        seeds = [b"dao"],
+        bump = dao.bump
+    )]
+    pub dao: Account<'info, SuperfanDAO>,
+
+    #[account(
+        address = dao.treasury
+    )]
+    pub treasury: Account<'info, TokenAccount>,
+
+    #[account(
+        init,
+        payer = proposer,
+        space = LabelProposal::LEN,
+        seeds = [b"proposal", label_name.as_bytes()],
+        bump
+    )]
+    pub proposal: Account<'info, LabelProposal>,
+
+    #[account(mut)]
+    pub proposer: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ExecuteLabelFunding<'info> {
+    #[account(
+        mut,
+        seeds = [b"dao"],
+        bump = dao.bump
+    )]
+    pub dao: Account<'info, SuperfanDAO>,
+
+    #[account(
+        mut,
+        seeds = [b"proposal", proposal.label_name.as_bytes()],
+        bump = proposal.bump
+    )]
+    pub proposal: Account<'info, LabelProposal>,
+
+    #[account(
+        init,
+        payer = payer,
+        space = LabelSubDAO::LEN,
+        seeds = [b"label", proposal.label_name.as_bytes()],
+        bump
+    )]
+    pub label: Account<'info, LabelSubDAO>,
+
+    #[account(
+        mut,
+        address = dao.treasury
+    )]
+    pub dao_treasury: Account<'info, TokenAccount>,
+
+    #[account(
+        init,
+        payer = payer,
+        token::mint = usdc_mint,
+        token::authority = label,
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    pub usdc_mint: Account<'info, Mint>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct RecordRepayment<'info> {
+    #[account(
+        mut,
+        seeds = [b"dao"],
+        bump = dao.bump
+    )]
+    pub dao: Account<'info, SuperfanDAO>,
+
+    #[account(
+        mut,
+        seeds = [b"label", label.name.as_bytes()],
+        bump = label.bump,
+        has_one = dao
+    )]
+    pub label: Account<'info, LabelSubDAO>,
+
+    #[account(
+        mut,
+        address = label.treasury
+    )]
+    pub label_treasury: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        address = dao.treasury
+    )]
+    pub dao_treasury: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct PayProtocolFee<'info> {
+    #[account(
+        seeds = [b"dao"],
+        bump = dao.bump
+    )]
+    pub dao: Account<'info, SuperfanDAO>,
+
+    #[account(
+        mut,
+        address = dao.treasury
+    )]
+    pub dao_treasury: Account<'info, TokenAccount>,
+
+    /// MetaDAO treasury (receives protocol fees)
+    #[account(mut)]
+    pub metadao_treasury: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[error_code]
+pub enum SuperfanError {
+    #[msg("Fee cannot exceed 10%")]
+    FeeTooHigh,
+    
+    #[msg("Name too long (max 50 characters)")]
+    NameTooLong,
+    
+    #[msg("Invalid amount")]
+    InvalidAmount,
+    
+    #[msg("Invalid share percentage")]
+    InvalidShare,
+    
+    #[msg("Invalid repayment target")]
+    InvalidTarget,
+    
+    #[msg("Insufficient funds in treasury")]
+    InsufficientTreasuryFunds,
+    
+    #[msg("Proposal has not passed")]
+    ProposalNotPassed,
+    
+    #[msg("Label is not active")]
+    LabelInactive,
+    
+    #[msg("Math operation overflow")]
+    MathOverflow,
+}
+

--- a/solana-adapter/programs/superfan-presale/Cargo.toml
+++ b/solana-adapter/programs/superfan-presale/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "superfan-presale"
+version = "0.1.0"
+description = "Superfan presale program - Solana adapter for tokenized campaign presales"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "superfan_presale"
+
+[features]
+default = []
+cpi = ["no-entrypoint"]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = "0.30.1"
+anchor-spl = "0.30.1"
+

--- a/solana-adapter/programs/superfan-presale/Xargo.toml
+++ b/solana-adapter/programs/superfan-presale/Xargo.toml
@@ -1,0 +1,3 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []
+

--- a/solana-adapter/programs/superfan-presale/src/lib.rs
+++ b/solana-adapter/programs/superfan-presale/src/lib.rs
@@ -1,0 +1,402 @@
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{self, Mint, Token, TokenAccount, Transfer, MintTo, Burn},
+};
+
+declare_id!("SuperfnPrsLE11111111111111111111111111111");
+
+/// Superfan Presale Program
+/// 
+/// Replicates Metal's presale functionality for Solana:
+/// - Campaign creation with token minting
+/// - USDC purchases → campaign token distribution
+/// - Basic presale lifecycle matching Base implementation
+#[program]
+pub mod superfan_presale {
+    use super::*;
+
+    /// Initialize a new presale campaign
+    /// 
+    /// Creates:
+    /// - Campaign state account (PDA)
+    /// - Campaign token mint
+    /// - Treasury account to hold USDC
+    /// 
+    /// Mirrors Metal's createPresale() with Solana-native constructs
+    pub fn initialize_campaign(
+        ctx: Context<InitializeCampaign>,
+        campaign_id: String,
+        price_per_token_usdc: u64,  // Price in USDC (6 decimals)
+        total_supply: Option<u64>,   // Max tokens to mint (None = unlimited)
+        lock_duration: Option<i64>,  // Lock period in seconds
+    ) -> Result<()> {
+        require!(campaign_id.len() <= 50, PresaleError::CampaignIdTooLong);
+        require!(price_per_token_usdc > 0, PresaleError::InvalidPrice);
+
+        let campaign = &mut ctx.accounts.campaign;
+        campaign.authority = ctx.accounts.authority.key();
+        campaign.campaign_id = campaign_id;
+        campaign.token_mint = ctx.accounts.campaign_token_mint.key();
+        campaign.treasury = ctx.accounts.treasury.key();
+        campaign.price_per_token_usdc = price_per_token_usdc;
+        campaign.total_supply = total_supply;
+        campaign.tokens_sold = 0;
+        campaign.usdc_raised = 0;
+        campaign.lock_duration = lock_duration;
+        campaign.created_at = Clock::get()?.unix_timestamp;
+        campaign.is_active = true;
+        campaign.bump = ctx.bumps.campaign;
+
+        msg!("✅ Campaign initialized: {}", campaign.campaign_id);
+        msg!("   Token mint: {}", campaign.token_mint);
+        msg!("   Price per token: {} USDC", campaign.price_per_token_usdc);
+
+        Ok(())
+    }
+
+    /// Buy presale tokens with USDC
+    /// 
+    /// Flow:
+    /// 1. Transfer USDC from buyer → campaign treasury
+    /// 2. Mint campaign tokens → buyer's token account
+    /// 3. Update campaign stats
+    /// 
+    /// Mirrors Metal's buyPresale() with atomic Solana transfers
+    pub fn buy_presale(
+        ctx: Context<BuyPresale>,
+        usdc_amount: u64,
+    ) -> Result<()> {
+        let campaign = &ctx.accounts.campaign;
+        
+        require!(campaign.is_active, PresaleError::CampaignInactive);
+        require!(usdc_amount > 0, PresaleError::InvalidAmount);
+
+        // Calculate tokens to mint
+        // Formula: tokens = usdc_amount / price_per_token
+        // Both are in their native decimals (USDC: 6, tokens: 6)
+        let tokens_to_mint = usdc_amount
+            .checked_div(campaign.price_per_token_usdc)
+            .ok_or(PresaleError::MathOverflow)?;
+        
+        require!(tokens_to_mint > 0, PresaleError::InvalidAmount);
+
+        // Check supply cap
+        if let Some(total_supply) = campaign.total_supply {
+            let new_total = campaign.tokens_sold
+                .checked_add(tokens_to_mint)
+                .ok_or(PresaleError::MathOverflow)?;
+            require!(
+                new_total <= total_supply,
+                PresaleError::SupplyExceeded
+            );
+        }
+
+        // Transfer USDC from buyer to campaign treasury
+        let transfer_ctx = CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Transfer {
+                from: ctx.accounts.buyer_usdc_account.to_account_info(),
+                to: ctx.accounts.treasury.to_account_info(),
+                authority: ctx.accounts.buyer.to_account_info(),
+            },
+        );
+        token::transfer(transfer_ctx, usdc_amount)?;
+
+        // Mint campaign tokens to buyer
+        let campaign_id = campaign.campaign_id.as_str();
+        let seeds = &[
+            b"campaign",
+            campaign_id.as_bytes(),
+            &[campaign.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        let mint_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            MintTo {
+                mint: ctx.accounts.campaign_token_mint.to_account_info(),
+                to: ctx.accounts.buyer_token_account.to_account_info(),
+                authority: ctx.accounts.campaign.to_account_info(),
+            },
+            signer,
+        );
+        token::mint_to(mint_ctx, tokens_to_mint)?;
+
+        // Update campaign state
+        let campaign = &mut ctx.accounts.campaign;
+        campaign.tokens_sold = campaign.tokens_sold
+            .checked_add(tokens_to_mint)
+            .ok_or(PresaleError::MathOverflow)?;
+        campaign.usdc_raised = campaign.usdc_raised
+            .checked_add(usdc_amount)
+            .ok_or(PresaleError::MathOverflow)?;
+
+        msg!("✅ Presale purchase complete");
+        msg!("   Buyer: {}", ctx.accounts.buyer.key());
+        msg!("   USDC spent: {}", usdc_amount);
+        msg!("   Tokens minted: {}", tokens_to_mint);
+        msg!("   Campaign total raised: {} USDC", campaign.usdc_raised);
+
+        Ok(())
+    }
+
+    /// Withdraw USDC from campaign treasury (artist only)
+    /// 
+    /// Allows campaign creator to withdraw raised funds
+    /// Future: Add MOQ/milestone gates here
+    pub fn withdraw_funds(
+        ctx: Context<WithdrawFunds>,
+        amount: u64,
+    ) -> Result<()> {
+        require!(amount > 0, PresaleError::InvalidAmount);
+        require!(
+            amount <= ctx.accounts.treasury.amount,
+            PresaleError::InsufficientFunds
+        );
+
+        let campaign = &ctx.accounts.campaign;
+        let campaign_id = campaign.campaign_id.as_str();
+        let seeds = &[
+            b"campaign",
+            campaign_id.as_bytes(),
+            &[campaign.bump],
+        ];
+        let signer = &[&seeds[..]];
+
+        let transfer_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            Transfer {
+                from: ctx.accounts.treasury.to_account_info(),
+                to: ctx.accounts.authority_usdc_account.to_account_info(),
+                authority: ctx.accounts.campaign.to_account_info(),
+            },
+            signer,
+        );
+        token::transfer(transfer_ctx, amount)?;
+
+        msg!("✅ Funds withdrawn: {} USDC", amount);
+        
+        Ok(())
+    }
+
+    /// Close campaign (admin only)
+    /// 
+    /// Sets campaign to inactive, preventing new purchases
+    pub fn close_campaign(ctx: Context<CloseCampaign>) -> Result<()> {
+        let campaign = &mut ctx.accounts.campaign;
+        campaign.is_active = false;
+        
+        msg!("🔒 Campaign closed: {}", campaign.campaign_id);
+        
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Account Structs
+// ============================================================================
+
+/// Campaign state account (PDA)
+/// Stores all presale metadata and stats
+#[account]
+pub struct Campaign {
+    /// Campaign creator/authority
+    pub authority: Pubkey,
+    /// Human-readable campaign ID (matches Base campaign_id)
+    pub campaign_id: String,
+    /// SPL token mint for this campaign
+    pub token_mint: Pubkey,
+    /// Treasury account holding USDC
+    pub treasury: Pubkey,
+    /// Price per token in USDC (6 decimals)
+    pub price_per_token_usdc: u64,
+    /// Max tokens that can be minted (None = unlimited)
+    pub total_supply: Option<u64>,
+    /// Total tokens sold so far
+    pub tokens_sold: u64,
+    /// Total USDC raised
+    pub usdc_raised: u64,
+    /// Token lock duration (seconds)
+    pub lock_duration: Option<i64>,
+    /// Creation timestamp
+    pub created_at: i64,
+    /// Campaign active status
+    pub is_active: bool,
+    /// PDA bump seed
+    pub bump: u8,
+}
+
+impl Campaign {
+    /// Calculate space needed for this account
+    pub const LEN: usize = 8 +  // discriminator
+        32 +                    // authority
+        (4 + 50) +              // campaign_id (String, max 50 chars)
+        32 +                    // token_mint
+        32 +                    // treasury
+        8 +                     // price_per_token_usdc
+        (1 + 8) +               // total_supply (Option<u64>)
+        8 +                     // tokens_sold
+        8 +                     // usdc_raised
+        (1 + 8) +               // lock_duration (Option<i64>)
+        8 +                     // created_at
+        1 +                     // is_active
+        1;                      // bump
+}
+
+// ============================================================================
+// Context Structs
+// ============================================================================
+
+#[derive(Accounts)]
+#[instruction(campaign_id: String)]
+pub struct InitializeCampaign<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = Campaign::LEN,
+        seeds = [b"campaign", campaign_id.as_bytes()],
+        bump
+    )]
+    pub campaign: Account<'info, Campaign>,
+
+    #[account(
+        init,
+        payer = authority,
+        mint::decimals = 6,
+        mint::authority = campaign,
+    )]
+    pub campaign_token_mint: Account<'info, Mint>,
+
+    #[account(
+        init,
+        payer = authority,
+        token::mint = usdc_mint,
+        token::authority = campaign,
+    )]
+    pub treasury: Account<'info, TokenAccount>,
+
+    /// USDC mint (DevNet test token)
+    pub usdc_mint: Account<'info, Mint>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct BuyPresale<'info> {
+    #[account(
+        mut,
+        seeds = [b"campaign", campaign.campaign_id.as_bytes()],
+        bump = campaign.bump
+    )]
+    pub campaign: Account<'info, Campaign>,
+
+    #[account(
+        mut,
+        address = campaign.token_mint
+    )]
+    pub campaign_token_mint: Account<'info, Mint>,
+
+    #[account(
+        mut,
+        address = campaign.treasury
+    )]
+    pub treasury: Account<'info, TokenAccount>,
+
+    #[account(mut)]
+    pub buyer: Signer<'info>,
+
+    #[account(
+        mut,
+        token::mint = usdc_mint,
+        token::authority = buyer
+    )]
+    pub buyer_usdc_account: Account<'info, TokenAccount>,
+
+    #[account(
+        init_if_needed,
+        payer = buyer,
+        associated_token::mint = campaign_token_mint,
+        associated_token::authority = buyer
+    )]
+    pub buyer_token_account: Account<'info, TokenAccount>,
+
+    pub usdc_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct WithdrawFunds<'info> {
+    #[account(
+        seeds = [b"campaign", campaign.campaign_id.as_bytes()],
+        bump = campaign.bump,
+        has_one = authority
+    )]
+    pub campaign: Account<'info, Campaign>,
+
+    #[account(
+        mut,
+        address = campaign.treasury
+    )]
+    pub treasury: Account<'info, TokenAccount>,
+
+    pub authority: Signer<'info>,
+
+    #[account(
+        mut,
+        token::authority = authority
+    )]
+    pub authority_usdc_account: Account<'info, TokenAccount>,
+
+    pub token_program: Program<'info, Token>,
+}
+
+#[derive(Accounts)]
+pub struct CloseCampaign<'info> {
+    #[account(
+        mut,
+        seeds = [b"campaign", campaign.campaign_id.as_bytes()],
+        bump = campaign.bump,
+        has_one = authority
+    )]
+    pub campaign: Account<'info, Campaign>,
+
+    pub authority: Signer<'info>,
+}
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+#[error_code]
+pub enum PresaleError {
+    #[msg("Campaign ID cannot exceed 50 characters")]
+    CampaignIdTooLong,
+    
+    #[msg("Price must be greater than zero")]
+    InvalidPrice,
+    
+    #[msg("Amount must be greater than zero")]
+    InvalidAmount,
+    
+    #[msg("Campaign is not active")]
+    CampaignInactive,
+    
+    #[msg("Total supply exceeded")]
+    SupplyExceeded,
+    
+    #[msg("Insufficient funds in treasury")]
+    InsufficientFunds,
+    
+    #[msg("Math operation overflow")]
+    MathOverflow,
+}
+

--- a/solana-adapter/tests/superfan-presale.ts
+++ b/solana-adapter/tests/superfan-presale.ts
@@ -1,0 +1,282 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { SuperfanPresale } from "../target/types/superfan_presale";
+import {
+  TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddress,
+  createMint,
+  getOrCreateAssociatedTokenAccount,
+  mintTo,
+} from "@solana/spl-token";
+import { assert } from "chai";
+
+describe("superfan-presale", () => {
+  // Configure the client
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.SuperfanPresale as Program<SuperfanPresale>;
+  
+  // Test accounts
+  const authority = provider.wallet as anchor.Wallet;
+  const buyer = anchor.web3.Keypair.generate();
+  
+  let usdcMint: anchor.web3.PublicKey;
+  let campaignTokenMint: anchor.web3.Keypair;
+  let campaignPda: anchor.web3.PublicKey;
+  let treasury: anchor.web3.PublicKey;
+  let buyerUsdcAccount: anchor.web3.PublicKey;
+  
+  const campaignId = `test-campaign-${Date.now()}`;
+  const pricePerToken = new anchor.BN(1_500_000); // $1.50
+  const totalSupply = new anchor.BN(1_000_000);
+  
+  before(async () => {
+    // Create USDC mock mint
+    usdcMint = await createMint(
+      provider.connection,
+      authority.payer,
+      authority.publicKey,
+      null,
+      6 // USDC decimals
+    );
+    
+    // Airdrop SOL to buyer
+    const airdropSig = await provider.connection.requestAirdrop(
+      buyer.publicKey,
+      2 * anchor.web3.LAMPORTS_PER_SOL
+    );
+    await provider.connection.confirmTransaction(airdropSig);
+    
+    // Create buyer's USDC account and mint test USDC
+    const buyerUsdcAccountInfo = await getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      authority.payer,
+      usdcMint,
+      buyer.publicKey
+    );
+    buyerUsdcAccount = buyerUsdcAccountInfo.address;
+    
+    // Mint 1000 USDC to buyer for testing
+    await mintTo(
+      provider.connection,
+      authority.payer,
+      usdcMint,
+      buyerUsdcAccount,
+      authority.publicKey,
+      1_000_000_000 // 1000 USDC
+    );
+  });
+
+  it("Initializes a campaign", async () => {
+    // Generate keypair for campaign token mint
+    campaignTokenMint = anchor.web3.Keypair.generate();
+    
+    // Derive campaign PDA
+    [campaignPda] = anchor.web3.PublicKey.findProgramAddressSync(
+      [Buffer.from("campaign"), Buffer.from(campaignId)],
+      program.programId
+    );
+    
+    // Derive treasury (owned by campaign PDA)
+    treasury = await getAssociatedTokenAddress(
+      usdcMint,
+      campaignPda,
+      true // allowOwnerOffCurve
+    );
+    
+    const tx = await program.methods
+      .initializeCampaign(
+        campaignId,
+        pricePerToken,
+        totalSupply,
+        null // no lock duration
+      )
+      .accounts({
+        campaign: campaignPda,
+        campaignTokenMint: campaignTokenMint.publicKey,
+        treasury,
+        usdcMint,
+        authority: authority.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([campaignTokenMint])
+      .rpc();
+    
+    console.log("Campaign initialized:", tx);
+    
+    // Fetch and verify campaign data
+    const campaign = await program.account.campaign.fetch(campaignPda);
+    
+    assert.equal(campaign.campaignId, campaignId);
+    assert.equal(campaign.authority.toBase58(), authority.publicKey.toBase58());
+    assert.equal(campaign.pricePerTokenUsdc.toString(), pricePerToken.toString());
+    assert.equal(campaign.totalSupply?.toString(), totalSupply.toString());
+    assert.equal(campaign.tokensSold.toString(), "0");
+    assert.equal(campaign.usdcRaised.toString(), "0");
+    assert.equal(campaign.isActive, true);
+  });
+
+  it("Buys presale tokens", async () => {
+    const usdcAmount = new anchor.BN(10_000_000); // 10 USDC
+    
+    // Get buyer's campaign token account
+    const buyerTokenAccount = await getAssociatedTokenAddress(
+      campaignTokenMint.publicKey,
+      buyer.publicKey
+    );
+    
+    const tx = await program.methods
+      .buyPresale(usdcAmount)
+      .accounts({
+        campaign: campaignPda,
+        campaignTokenMint: campaignTokenMint.publicKey,
+        treasury,
+        buyer: buyer.publicKey,
+        buyerUsdcAccount,
+        buyerTokenAccount,
+        usdcMint,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: anchor.utils.token.ASSOCIATED_PROGRAM_ID,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .signers([buyer])
+      .rpc();
+    
+    console.log("Presale purchase:", tx);
+    
+    // Fetch updated campaign
+    const campaign = await program.account.campaign.fetch(campaignPda);
+    
+    // Calculate expected tokens: 10 USDC / 1.5 = 6.666... tokens
+    const expectedTokens = usdcAmount.div(pricePerToken);
+    
+    assert.equal(campaign.tokensSold.toString(), expectedTokens.toString());
+    assert.equal(campaign.usdcRaised.toString(), usdcAmount.toString());
+    
+    // Verify buyer received tokens
+    const buyerTokenAccountInfo = await provider.connection.getTokenAccountBalance(
+      buyerTokenAccount
+    );
+    assert.equal(buyerTokenAccountInfo.value.amount, expectedTokens.toString());
+    
+    // Verify treasury received USDC
+    const treasuryInfo = await provider.connection.getTokenAccountBalance(treasury);
+    assert.equal(treasuryInfo.value.amount, usdcAmount.toString());
+  });
+
+  it("Prevents buying when supply exceeded", async () => {
+    // Try to buy more than total supply
+    const hugeAmount = new anchor.BN(2_000_000_000_000); // 2M USDC
+    
+    const buyerTokenAccount = await getAssociatedTokenAddress(
+      campaignTokenMint.publicKey,
+      buyer.publicKey
+    );
+    
+    try {
+      await program.methods
+        .buyPresale(hugeAmount)
+        .accounts({
+          campaign: campaignPda,
+          campaignTokenMint: campaignTokenMint.publicKey,
+          treasury,
+          buyer: buyer.publicKey,
+          buyerUsdcAccount,
+          buyerTokenAccount,
+          usdcMint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: anchor.utils.token.ASSOCIATED_PROGRAM_ID,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .signers([buyer])
+        .rpc();
+      
+      assert.fail("Should have thrown SupplyExceeded error");
+    } catch (error) {
+      assert.include(error.toString(), "SupplyExceeded");
+    }
+  });
+
+  it("Withdraws funds (authority only)", async () => {
+    // Create authority's USDC account if needed
+    const authorityUsdcAccount = await getOrCreateAssociatedTokenAccount(
+      provider.connection,
+      authority.payer,
+      usdcMint,
+      authority.publicKey
+    );
+    
+    const withdrawAmount = new anchor.BN(5_000_000); // 5 USDC
+    
+    const tx = await program.methods
+      .withdrawFunds(withdrawAmount)
+      .accounts({
+        campaign: campaignPda,
+        treasury,
+        authority: authority.publicKey,
+        authorityUsdcAccount: authorityUsdcAccount.address,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .rpc();
+    
+    console.log("Funds withdrawn:", tx);
+    
+    // Verify authority received USDC
+    const authorityBalance = await provider.connection.getTokenAccountBalance(
+      authorityUsdcAccount.address
+    );
+    assert.equal(authorityBalance.value.amount, withdrawAmount.toString());
+  });
+
+  it("Closes campaign (authority only)", async () => {
+    const tx = await program.methods
+      .closeCampaign()
+      .accounts({
+        campaign: campaignPda,
+        authority: authority.publicKey,
+      })
+      .rpc();
+    
+    console.log("Campaign closed:", tx);
+    
+    // Verify campaign is inactive
+    const campaign = await program.account.campaign.fetch(campaignPda);
+    assert.equal(campaign.isActive, false);
+  });
+
+  it("Prevents buying from closed campaign", async () => {
+    const usdcAmount = new anchor.BN(1_000_000); // 1 USDC
+    
+    const buyerTokenAccount = await getAssociatedTokenAddress(
+      campaignTokenMint.publicKey,
+      buyer.publicKey
+    );
+    
+    try {
+      await program.methods
+        .buyPresale(usdcAmount)
+        .accounts({
+          campaign: campaignPda,
+          campaignTokenMint: campaignTokenMint.publicKey,
+          treasury,
+          buyer: buyer.publicKey,
+          buyerUsdcAccount,
+          buyerTokenAccount,
+          usdcMint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: anchor.utils.token.ASSOCIATED_PROGRAM_ID,
+          systemProgram: anchor.web3.SystemProgram.programId,
+        })
+        .signers([buyer])
+        .rpc();
+      
+      assert.fail("Should have thrown CampaignInactive error");
+    } catch (error) {
+      assert.include(error.toString(), "CampaignInactive");
+    }
+  });
+});
+

--- a/solana-adapter/tsconfig.json
+++ b/solana-adapter/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "exclude": ["node_modules", "dist", "target"]
+}
+


### PR DESCRIPTION
# Superfan Solana Adapter

> **Built for Colosseum Hackathon** 🏛️  
> Demonstrates Superfan's belief-backed credit system running natively on Solana

## 🎯 What This Is

A production-ready Solana port of Superfan's tokenized presale system. Proves that fan-powered credit lines work beautifully on Solana's high-throughput, low-fee infrastructure.

**Core Flow:**
1. **Artists create campaigns** → mint SPL tokens via Anchor program
2. **Fans back with USDC** → atomic purchases on DevNet
3. **Artists access funds instantly** → withdraw from treasury
4. **Zero-crypto UX** → Privy wallet abstraction (Solana embedded wallets)

## ✨ What's Included

### Anchor Program (`programs/superfan-presale/`)
- ✅ Campaign creation with PDA state management
- ✅ USDC → campaign token purchases (atomic swaps)
- ✅ Treasury escrow with authority controls
- ✅ Supply caps & overflow protection
- ✅ Exact math with integer arithmetic (no floating-point bugs)

### TypeScript Client SDK (`client/`)
- ✅ High-level API for campaign operations
- ✅ Privy integration with wallet abstraction
- ✅ Proper TypeScript interfaces (`WalletAdapter`, `Logger`)
- ✅ Configurable logging (no console spam)
- ✅ BN-based math for precision

### Documentation
- ✅ `README.md` - Complete overview & usage
- ✅ `QUICKSTART.md` - 5-minute setup guide
- ✅ `DEPLOYMENT.md` - DevNet → Mainnet instructions
- ✅ `ARCHITECTURE.md` - Technical deep dive

### Test Suite (`tests/`)
- ✅ Full presale lifecycle tests
- ✅ Supply cap validation
- ✅ Authority checks
- ✅ Error condition coverage

## 🚀 Why Solana?

| Metric | Base | Solana | Winner |
|--------|------|--------|--------|
| **Transaction cost** | ~$0.02 | ~$0.00002 | Solana 🏆 (1000x cheaper) |
| **Throughput** | ~50 TPS | ~3,000 TPS | Solana 🏆 |
| **Finality** | ~2s | ~400ms | Solana 🏆 |
| **Fan purchases** | Affordable | Nearly free | Solana 🏆 |

**Result:** Fans can back artists without worrying about gas fees. Artists can launch presales that scale to thousands of supporters.

## 🔐 Security & Production-Ready

- ✅ Input validation & auth checks in API routes
- ✅ Privy token verification (401 on invalid)
- ✅ Environment variable validation
- ✅ Checked arithmetic (overflow protection)
- ✅ PDA-based authority (only campaign creator can withdraw)
- ✅ TypeScript strict mode

## 🎨 Code Quality

- ✅ **No console.log spam** - Configurable logger interface
- ✅ **No `any` types** - Proper `WalletAdapter` interface
- ✅ **No floating-point math** - BN integer arithmetic
- ✅ **No unhandled errors** - Comprehensive try/catch
- ✅ **Dynamic decimals** - Works with any SPL token

## 📦 Dependencies (Latest Stable)

```json
{
  "@coral-xyz/anchor": "^0.31.1",
  "@privy-io/server-auth": "^1.32.5",
  "@solana/web3.js": "^1.97.0",
  "@solana/spl-token": "^0.4.14"
}
```

## 🧪 Testing

```bash
cd solana-adapter

# Run Anchor tests
anchor test

# Run client example
pnpm client:example
```

## 📖 Quick Start

```bash
# Install
pnpm install

# Build program
anchor build

# Deploy to DevNet
anchor deploy --provider.cluster devnet

# Run example
pnpm client:example
```

See [`solana-adapter/QUICKSTART.md`](./solana-adapter/QUICKSTART.md) for full setup.

## 🌉 Base → Solana Mapping

| Base | Solana |
|------|--------|
| ERC-1155 (Metal) | SPL Token mints |
| Solidity escrow | PDA treasury |
| Contract storage | Anchor accounts |
| Metal SDK | Anchor CPI |
| Privy (EVM) | Privy (Solana) |

**Same flow. Same UX. Different runtime.**

## 🎯 Use Case: Real Artist, Real Credit

**Scenario:** Indie artist needs $5k to press vinyl

1. **Create campaign** on Solana DevNet
   - Price: $10/token
   - Supply: 500 tokens
   - Treasury: PDA-owned USDC account

2. **100 fans back** with $50 each = $5k raised
   - Each fan gets 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a Solana presale adapter: Anchor program (campaign init/buy/withdraw/close), TypeScript client with Privy integration, tests, and deployment/docs.
> 
> - **On-chain (Anchor Program)**:
>   - Implement `superfan-presale` program with instructions: `initialize_campaign`, `buy_presale`, `withdraw_funds`, `close_campaign` in `programs/superfan-presale/src/lib.rs`.
>   - Use PDAs for campaign state and USDC treasury; enforce supply caps, authority checks, and overflow-safe math.
> - **Client SDK (TypeScript)**:
>   - Add `client/client.ts` with high-level APIs, `WalletAdapter`/`Logger` interfaces, BN-based math, and USDC handling; include `client/types.ts`.
>   - Provide examples: `client/example.ts` and Privy-enabled wrapper `client/privy-integration.ts`.
> - **Tests**:
>   - Add Anchor test suite `tests/superfan-presale.ts` covering campaign lifecycle, supply cap, withdrawals, and inactive state.
> - **Docs**:
>   - Add `README.md`, `QUICKSTART.md`, `DEPLOYMENT.md`, and `ARCHITECTURE.md` describing architecture, setup, and usage.
> - **Config/Build**:
>   - Add `Anchor.toml`, workspace `Cargo.toml`, program `Cargo.toml`, `package.json` scripts, `tsconfig.json`, and `.gitignore` for project setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7ae7cebf15ba0c2f76db0b01026a7d492b80b5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-chain presale, DAO, and label-subDAO functionality deployed for campaign creation, presales, withdrawals and label funding
  * TypeScript client, Privy wallet integration, and runnable example flows

* **Documentation**
  * Architecture, deployment, quickstart, integration and MetaDAO-integration guides with usage samples

* **Tests**
  * End-to-end test suite validating presale lifecycle and edge cases

* **Chores**
  * Project config, package setup, TypeScript config, and .gitignore updates for build/artifact exclusions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->