### PR TITLE
Feat: Leaderboard

### DIFF
--- a/app/api/clubs/[id]/leaderboard/route.ts
+++ b/app/api/clubs/[id]/leaderboard/route.ts
@@ -1,0 +1,157 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/app/api/supabase";
+
+/**
+ * GET /api/clubs/[id]/leaderboard
+ * Get leaderboard for a club - only members who have made purchases, ordered by total invested amount
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { id: clubId } = await params;
+    
+    if (!clubId) {
+      return NextResponse.json(
+        { error: "Club ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Get active memberships for this club, ordered by points (descending)
+    // Filter to only members who have made purchases (credit_purchases OR reward_claims)
+    // Join with users table to get user names
+    
+    // First, get all memberships
+    // Status points come from point_wallets.earned_pts, not club_memberships.points
+    const { data: allMemberships, error: membershipsError } = await supabase
+      .from('club_memberships')
+      .select(`
+        id,
+        user_id,
+        current_status,
+        last_activity_at,
+        join_date,
+        created_at,
+        user:users!club_memberships_user_id_fkey (
+          id,
+          name,
+          email
+        )
+      `)
+      .eq('club_id', clubId)
+      .eq('status', 'active');
+
+    if (membershipsError) {
+      console.error('[Leaderboard] Error fetching memberships:', membershipsError);
+      return NextResponse.json(
+        { error: "Failed to fetch memberships" },
+        { status: 500 }
+      );
+    }
+
+    if (!allMemberships || allMemberships.length === 0) {
+      return NextResponse.json({ leaderboard: [] });
+    }
+
+    // Get all user IDs who have made purchases (from credit_purchases or reward_claims)
+    const userIds = allMemberships.map(m => m.user_id);
+    
+    // Get status points from point_wallets for these users
+    // Status points = earned_pts from point_wallets (not club_memberships.points)
+    const { data: wallets, error: walletsError } = await supabase
+      .from('point_wallets')
+      .select('user_id, earned_pts')
+      .eq('club_id', clubId)
+      .in('user_id', userIds);
+    
+    if (walletsError) {
+      console.error('[Leaderboard] Error fetching point wallets:', walletsError);
+    }
+    
+    // Create a map of user_id -> earned_pts (status points)
+    const statusPointsByUser = new Map<string, number>();
+    wallets?.forEach(w => {
+      statusPointsByUser.set(w.user_id, w.earned_pts || 0);
+    });
+    
+    // Get credit_purchases with amounts
+    const { data: creditPurchases, error: creditError } = await supabase
+      .from('credit_purchases')
+      .select('user_id, price_paid_cents')
+      .eq('club_id', clubId)
+      .eq('status', 'completed')
+      .in('user_id', userIds);
+
+    if (creditError) {
+      console.error('[Leaderboard] Error fetching credit purchases:', creditError);
+    }
+
+    // Get reward_claims (purchased items) with amounts
+    const { data: rewardClaims, error: rewardError } = await supabase
+      .from('reward_claims')
+      .select('user_id, paid_price_cents')
+      .eq('club_id', clubId)
+      .in('user_id', userIds);
+
+    if (rewardError) {
+      console.error('[Leaderboard] Error fetching reward claims:', rewardError);
+    }
+
+    // Calculate total invested per user (in cents)
+    const totalInvestedByUser = new Map<string, number>();
+    
+    // Add credit purchases
+    creditPurchases?.forEach(p => {
+      const current = totalInvestedByUser.get(p.user_id) || 0;
+      totalInvestedByUser.set(p.user_id, current + (p.price_paid_cents || 0));
+    });
+    
+    // Add reward claims
+    rewardClaims?.forEach(r => {
+      const current = totalInvestedByUser.get(r.user_id) || 0;
+      totalInvestedByUser.set(r.user_id, current + (r.paid_price_cents || 0));
+    });
+
+    // Filter memberships to only those who have made purchases
+    const memberships = allMemberships.filter(m => totalInvestedByUser.has(m.user_id));
+    
+    // Add total invested to each membership and sort by invested amount (descending)
+    const membershipsWithInvested = memberships.map(m => ({
+      ...m,
+      total_invested_cents: totalInvestedByUser.get(m.user_id) || 0
+    }));
+    
+    const sortedMemberships = membershipsWithInvested
+      .sort((a, b) => b.total_invested_cents - a.total_invested_cents)
+      .slice(0, 100);
+
+    // Transform the data to flatten user info
+    // Use earned_pts from point_wallets as status points (not club_memberships.points)
+    const leaderboard = sortedMemberships.map((membership: any) => ({
+      id: membership.id,
+      user_id: membership.user_id,
+      points: statusPointsByUser.get(membership.user_id) || 0, // Status points from point_wallets
+      total_invested_cents: membership.total_invested_cents || 0,
+      current_status: membership.current_status || 'cadet',
+      last_activity_at: membership.last_activity_at,
+      join_date: membership.join_date,
+      created_at: membership.created_at,
+      user: {
+        id: membership.user?.id,
+        name: membership.user?.name || (membership.user?.email ? membership.user.email.split('@')[0] : 'Anonymous'),
+        email: membership.user?.email,
+      }
+    })) || [];
+
+    return NextResponse.json({ leaderboard });
+  } catch (error) {
+    console.error('[Leaderboard] Unexpected error:', error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/tap-in/route.ts
+++ b/app/api/tap-in/route.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 
 import { verifyUnifiedAuth } from "../auth";
 import { type } from "arktype";
+import { TAP_IN_POINT_VALUES } from "@/lib/points";
 
 interface TapInMetadata {
   qr_id?: string;
@@ -20,16 +21,8 @@ const tapInSchema = type({
   idempotency_key: "string?" // Optional client-provided idempotency key
 });
 
-// Point values for different tap-in sources (from memo)
-const POINT_VALUES = {
-  qr_code: 20,
-  nfc: 20,
-  link: 10,
-  show_entry: 100,
-  merch_purchase: 50,
-  presave: 40,
-  default: 10
-};
+// Use shared point values from lib/points.ts (single source of truth)
+const POINT_VALUES = TAP_IN_POINT_VALUES;
 
 export async function POST(request: NextRequest) {
   const auth = await verifyUnifiedAuth(request);

--- a/components/club-details-modal.tsx
+++ b/components/club-details-modal.tsx
@@ -13,6 +13,8 @@ import {
   Share2,
   MapPin,
   ChevronLeft,
+  Lock,
+  Info,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useUnifiedAuth } from "@/lib/unified-auth-context";
@@ -22,7 +24,7 @@ import type { CampaignData } from "@/types/campaign.types";
 import { getNextStatus, getPointsToNext, STATUS_COLORS } from "@/types/club.types";
 import { STATUS_THRESHOLDS } from "@/lib/status";
 import { useUnifiedPoints } from "@/hooks/unified-economy/use-unified-points";
-import { useClub, useUserClubData, useJoinClub } from "@/hooks/use-clubs";
+import { useClub, useUserClubData, useJoinClub, useClubLeaderboard, type LeaderboardMember } from "@/hooks/use-clubs";
 import { ClubMediaDisplay } from "@/components/club-media-display";
 import UnifiedPointsWallet from "./unified-economy/unified-points-wallet";
 import UnlockRedemption from "./unlock-redemption";
@@ -31,6 +33,12 @@ import PerkDetailsModal from "./perk-details-modal";
 import Spinner from "./ui/spinner";
 import { formatDate } from "@/lib/utils";
 import { CampaignProgressCard } from "./campaign-progress-card";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "./ui/tabs";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+import { Badge } from "./ui/badge";
+import { Skeleton } from "./ui/skeleton";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import { useFarcaster } from "@/lib/farcaster-context";
 import { navigateToCheckout } from "@/lib/navigation-utils";
 import { useSendUSDC } from "@/hooks/use-usdc-payment";
@@ -74,6 +82,201 @@ const STATUS_ICONS = {
   headliner: Trophy,
   superfan: Crown,
 };
+
+// Leaderboard Content Component
+function LeaderboardContent({ clubId, currentUserId }: { clubId: string; currentUserId?: string }) {
+  const { data: leaderboard, isLoading, error } = useClubLeaderboard(clubId);
+  const [sortBy, setSortBy] = useState<'invested' | 'points'>('invested');
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="rounded-xl border border-gray-800 bg-gray-900/30 p-4">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+              <Skeleton className="h-6 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/30 p-6 text-center">
+        <Trophy className="h-12 w-12 mx-auto mb-4 text-primary/50" />
+        <h4 className="font-semibold text-white mb-2">Error Loading Leaderboard</h4>
+        <p className="text-gray-400">
+          Please try again later
+        </p>
+      </div>
+    );
+  }
+
+  if (!leaderboard || leaderboard.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-800 bg-gray-900/30 p-6 text-center">
+        <Trophy className="h-12 w-12 mx-auto mb-4 text-primary/50" />
+        <h4 className="font-semibold text-white mb-2">No Members Yet</h4>
+        <p className="text-gray-400">
+          Be the first to invest and join the leaderboard!
+        </p>
+      </div>
+    );
+  }
+
+  const getRankIcon = (rank: number) => {
+    if (rank === 1) return "🥇";
+    if (rank === 2) return "🥈";
+    if (rank === 3) return "🥉";
+    return null;
+  };
+
+  // Sort leaderboard based on selected option
+  const sortedLeaderboard = [...leaderboard].sort((a, b) => {
+    if (sortBy === 'invested') {
+      return (b.total_invested_cents || 0) - (a.total_invested_cents || 0);
+    } else {
+      return (b.points || 0) - (a.points || 0);
+    }
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Sort Selector */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-400">Sort by:</span>
+        <div className="flex items-center gap-2">
+          {sortBy === 'points' && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-300 transition-colors"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Info className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  <p className="text-sm">
+                    Status points are earned through tap-ins and activities:
+                    <br />• Show entry: 100 pts
+                    <br />• Merch purchase: 50 pts
+                    <br />• Presave: 40 pts
+                    <br />• QR code/NFC: 20 pts
+                    <br />• Link share: 10 pts
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+          <Select value={sortBy} onValueChange={(value: 'invested' | 'points') => setSortBy(value)}>
+            <SelectTrigger className="w-[180px] bg-gray-900/50 border-gray-700">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="invested">Backing</SelectItem>
+              <SelectItem value="points">Status</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Leaderboard List */}
+      <div className="space-y-3">
+        {sortedLeaderboard.map((member, index) => {
+        const rank = index + 1;
+        const rankIcon = getRankIcon(rank);
+        const isCurrentUser = member.user_id === currentUserId;
+        const StatusIconComponent = STATUS_ICONS[member.current_status as keyof typeof STATUS_ICONS] ?? Users;
+        const statusColor = STATUS_COLORS[member.current_status as ClubStatus] || "text-gray-400";
+
+        return (
+          <motion.div
+            key={member.id}
+            className={`rounded-xl border ${
+              isCurrentUser 
+                ? "border-primary/50 bg-primary/10" 
+                : "border-gray-800 bg-gray-900/30"
+            } p-4 transition-all hover:bg-gray-900/50`}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.05, duration: 0.3 }}
+          >
+            <div className="flex items-center gap-4">
+              {/* Rank */}
+              <div className="flex-shrink-0 w-10 text-center">
+                {rankIcon ? (
+                  <span className="text-2xl">{rankIcon}</span>
+                ) : (
+                  <span className={`text-lg font-bold ${isCurrentUser ? "text-primary" : "text-gray-400"}`}>
+                    #{rank}
+                  </span>
+                )}
+              </div>
+
+              {/* Avatar */}
+              <Avatar className="h-12 w-12 border-2 border-gray-700">
+                <AvatarImage src={`/placeholder-user.jpg`} alt={member.user.name || "User"} />
+                <AvatarFallback className="bg-primary/20 text-primary">
+                  {member.user.name?.charAt(0).toUpperCase() || "?"}
+                </AvatarFallback>
+              </Avatar>
+
+              {/* User Info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h4 className={`font-semibold truncate ${isCurrentUser ? "text-primary" : "text-white"}`}>
+                    {member.user.name || "Anonymous"}
+                  </h4>
+                  {isCurrentUser && (
+                    <Badge variant="outline" className="text-xs border-primary/50 text-primary">
+                      You
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <StatusIconComponent className={`h-4 w-4 ${statusColor}`} />
+                  <span className={`text-sm ${statusColor} capitalize`}>
+                    {member.current_status}
+                  </span>
+                </div>
+              </div>
+
+              {/* Amount/Points Display */}
+              <div className="flex-shrink-0 text-right">
+                {sortBy === 'invested' ? (
+                  <>
+                    <div className="text-lg font-bold text-white">
+                      ${((member.total_invested_cents || 0) / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </div>
+                    <div className="text-xs text-gray-400">invested</div>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-lg font-bold text-white">
+                      {member.points.toLocaleString()}
+                    </div>
+                    <div className="text-xs text-gray-400">points</div>
+                  </>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        );
+      })}
+      </div>
+    </div>
+  );
+}
 
 
 
@@ -1004,8 +1207,25 @@ export default function ClubDetailsModal({
             </div>
           </div>
 
+          {/* Tabs Navigation */}
+          <div className="pt-4 pb-0 border-b border-gray-800">
+            <Tabs defaultValue="overview" className="w-full">
+              <div className="px-6">
+                <TabsList className="grid w-full grid-cols-3 bg-gray-900/50">
+                <TabsTrigger value="overview" className="data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
+                  Overview
+                </TabsTrigger>
+                <TabsTrigger value="leaderboard" className="data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
+                  Leaderboard
+                </TabsTrigger>
+                <TabsTrigger value="chat" className="data-[state=active]:bg-primary/20 data-[state=active]:text-primary">
+                  Chat
+                </TabsTrigger>
+              </TabsList>
+              </div>
 
-          {/* Club details */}
+              {/* Overview Tab - All existing content */}
+              <TabsContent value="overview" className="mt-0">
           <div className="px-6 py-6">
             {/* Description */}
             <div className="mb-8">
@@ -1254,6 +1474,56 @@ export default function ClubDetailsModal({
 
             {/* Bottom spacing for anchored button */}
             <div className="h-20" />
+          </div>
+              </TabsContent>
+
+              {/* Leaderboard Tab */}
+              <TabsContent value="leaderboard" className="mt-0">
+                <div className="px-6 py-6">
+                  <div className="mb-8">
+                    <h3 className="mb-4 text-xl font-semibold">Leaderboard</h3>
+                    <p className="text-sm text-gray-400 mb-6">
+                      Members of this club ranked by spend and status
+                    </p>
+                    
+                    <LeaderboardContent clubId={club.id} currentUserId={user?.id} />
+                  </div>
+                </div>
+              </TabsContent>
+
+              {/* Chat Tab */}
+              <TabsContent value="chat" className="mt-0">
+                <div className="px-6 py-6">
+                  <div className="mb-8">
+                    <h3 className="mb-4 text-xl font-semibold">Chat</h3>
+                    {membership ? (
+                      <div className="rounded-2xl border border-gray-800 bg-gray-900/30 p-6 text-center">
+                        <Users className="h-12 w-12 mx-auto mb-4 text-primary/50" />
+                        <h4 className="font-semibold text-white mb-2">Coming Soon</h4>
+                        <p className="text-gray-400">
+                          Connect with other club members
+                        </p>
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-gray-800 bg-gray-900/30 p-6 text-center">
+                        <Lock className="h-12 w-12 mx-auto mb-4 text-gray-500" />
+                        <h4 className="font-semibold text-white mb-2">Members Only</h4>
+                        <p className="text-gray-400 mb-4">
+                          Join this club to access the chat
+                        </p>
+                        <button
+                          onClick={handleJoinClub}
+                          disabled={joinClubMutation.isPending}
+                          className="rounded-lg bg-primary px-4 py-2 font-semibold text-white hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                          {joinClubMutation.isPending ? "Joining..." : "Join Club"}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </TabsContent>
+            </Tabs>
           </div>
           </div>
 

--- a/hooks/use-clubs.ts
+++ b/hooks/use-clubs.ts
@@ -276,3 +276,40 @@ export function useCanAccessUnlock(userId: string | null, clubId: string | null,
 
   return userStatusIndex >= requiredStatusIndex;
 }
+
+// Leaderboard member type
+export interface LeaderboardMember {
+  id: string;
+  user_id: string;
+  points: number;
+  total_invested_cents: number;
+  current_status: ClubStatus;
+  last_activity_at: string;
+  join_date: string;
+  created_at: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  };
+}
+
+// Get club leaderboard
+export function useClubLeaderboard(clubId: string | null) {
+  return useQuery({
+    queryKey: ['club-leaderboard', clubId],
+    queryFn: async (): Promise<LeaderboardMember[]> => {
+      if (!clubId) return [];
+
+      const response = await fetch(`/api/clubs/${clubId}/leaderboard`);
+      
+      if (!response.ok) {
+        throw new Error('Failed to fetch leaderboard');
+      }
+
+      const data = await response.json() as { leaderboard: LeaderboardMember[] };
+      return data.leaderboard || [];
+    },
+    enabled: !!clubId,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements a club leaderboard end-to-end (API + hook + UI tab with sorting) and switches tap-in to shared point values.
> 
> - **Backend**:
>   - **Leaderboard API**: Add `GET /api/clubs/[id]/leaderboard` in `app/api/clubs/[id]/leaderboard/route.ts` to return members with purchases, totals, and status points (joins wallets/purchases/claims; returns warnings on partial failures).
>   - **Tap-in points**: Use shared `TAP_IN_POINT_VALUES` in `app/api/tap-in/route.ts`.
> - **Frontend**:
>   - **Club modal tabs**: Add tabs (`overview`, `leaderboard`, `chat`) in `components/club-details-modal.tsx`.
>   - **Leaderboard UI**: New sortable leaderboard (by `total_invested_cents` or `points`) with ranks, status, and current-user highlight; uses `TAP_IN_POINT_VALUES` tooltip.
> - **Hooks**:
>   - Add `LeaderboardMember` type and `useClubLeaderboard(clubId)` in `hooks/use-clubs.ts` to fetch from `/api/clubs/[id]/leaderboard`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bf8ebf1523853d9dcdb585f3df6a85337194559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added club leaderboards displaying member rankings by investment and points
  * Introduced sortable Leaderboard tab in club details modal with member profiles, status indicators, and invested amounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->